### PR TITLE
Update dependabot.yml with new `directories` syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,11 @@
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/HadesAPI" # Location of package manifests
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/HadesScheduler" # Location of package manifests
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/shared" # Location of package manifests
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/HadesCloneContainer" # Location of package manifests
+    directories: 
+      - "/HadesAPI"
+      - "/HadesScheduler"
+      - "/HadesCloneContainer"
+      - "/shared"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
GitHub updated `dependabot` and allows now to specify multiple directories using the `directories` keyword

See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories