### PR TITLE
Update Dependabot to exclude alpha and beta updates + Setting to grou…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,27 @@ updates:
       - "/shared"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+        versions: ["*-alpha", "*-beta"]
+    groups:
+      golang-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        versions: ["*-alpha", "*-beta"]
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management settings to ignore alpha and beta pre-release updates for Go modules and GitHub Actions.
  * Grouped Go and GitHub Actions dependencies for more organized update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->