### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build Docker Images
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ls1intum/hades/security/code-scanning/2](https://github.com/ls1intum/hades/security/code-scanning/2)

To resolve this issue, we need to set an explicit `permissions` block at the workflow level. This will limit the permissions granted to the `GITHUB_TOKEN` used by the workflow. Based on the workflow's purpose of building Docker images and potentially pushing them to a registry, the following permissions are appropriate:
- `contents: read` to allow the workflow to read from the repository.
- `packages: write` to allow the workflow to push Docker images.

The fix involves adding a `permissions` block to the root of the workflow file, which will apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
