### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     strategy:
       matrix:
         directory: [ 'shared', 'HadesAPI' ]


### PR DESCRIPTION
Potential fix for [https://github.com/ls1intum/hades/security/code-scanning/3](https://github.com/ls1intum/hades/security/code-scanning/3)

To fix the issue, we add a `permissions` key at either the workflow level or the job level. Since this workflow only contains one job (`test`), adding permissions at the job level makes the scope clearer. The minimal permissions required for this workflow are:
- `contents: read` to allow reading repository contents such as files.
- `actions: write` to allow uploading test results as artifacts.

The edit will involve modifying the `.github/workflows/test.yml` file by adding the `permissions` block under the `test` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
