### PR TITLE
Use traefik action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,17 +74,20 @@ jobs:
       image-name: ls1intum/hades/hades-operator
       docker-file: ./HadesScheduler/HadesOperator/Dockerfile
     secrets: inherit
+  
+  deploy-traefik:
+    needs: [build-api, build-scheduler]
+    uses: ls1intum/.github/.github/workflows/deploy-docker-traefik.yml@feat/traefik-deployment
+    with:
+      environment: hades-test
+      image-tag: v3.6
+    secrets: inherit
 
   deploy:
     needs: [build-api, build-scheduler]
     runs-on: ubuntu-latest
     environment: hades-test
     steps:
-      - name: Setup Traefik
-        uses: ls1intum/.github/.github/workflows/deploy-docker-traefik.yml@feat/traefik-deployment
-        with:
-          environment: hades-test
-          image-tag: v3.6
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: hades-test
     steps:
+      - name: Setup Traefik
+        uses: ls1intum/.github/.github/workflows/deploy-docker-traefik.yml@feat/traefik-deployment
+        with:
+          environment: hades-test
+          image-tag: v3.6
+
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -105,7 +111,7 @@ jobs:
           proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
-          source: "docker-compose.test.yml,traefik/traefik.yml"
+          source: "docker-compose.test.yml"
           target: /opt/hades
           strip_components: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
   
   deploy-traefik:
     needs: [build-api, build-scheduler]
-    uses: ls1intum/.github/.github/workflows/deploy-docker-traefik.yml@feat/traefik-deployment
+    uses: ls1intum/.github/.github/workflows/deploy-docker-traefik.yml@main
     with:
       environment: hades-test
       image-tag: v3.6
@@ -91,18 +91,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Create deployment directory on VM
-        uses: appleboy/ssh-action@v1.2.5
-        with:
-          host: ${{ vars.VM_HOST }}
-          username: ${{ vars.VM_USERNAME }}
-          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
-          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
-          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
-          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
-          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
-          script: mkdir -p /opt/hades/traefik
 
       - name: Copy deployment files to VM
         uses: appleboy/scp-action@v1.0.0
@@ -129,8 +117,6 @@ jobs:
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
           script: |
-            touch /opt/hades/traefik/acme.json
-            chmod 600 /opt/hades/traefik/acme.json
             install -m 600 /dev/null /opt/hades/.env
             cat > /opt/hades/.env <<'EOF'
             IMAGE_TAG=${{ needs.build-api.outputs.image_tag }}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,29 +1,13 @@
 version: "3.8"
 
 services:
-  traefik:
-    image: traefik:v3.6
-    container_name: traefik
-    command:
-      - --configFile=/etc/traefik/traefik.yml
-      - --certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
-      - ./traefik/acme.json:/etc/traefik/acme.json
-    restart: unless-stopped
-    networks:
-      - hades
-
   hadesAPI:
     image: ghcr.io/ls1intum/hades/hades-api:${IMAGE_TAG:?IMAGE_TAG is required}
     expose:
       - "8080"
     networks:
       - hades
+      - traefik
     depends_on:
       nats:
         condition: service_healthy
@@ -37,7 +21,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.hadesapi.rule=Host(`${HADES_API_HOST}`)"
       - "traefik.http.routers.hadesapi.entrypoints=websecure"
-      - "traefik.http.routers.hadesapi.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.hadesapi.tls.certresolver=harica"
       - "traefik.http.services.hadesapi.loadbalancer.server.port=8080"
     restart: unless-stopped
 
@@ -77,3 +61,5 @@ services:
 networks:
   hades:
     external: false
+  traefik:
+    external: true


### PR DESCRIPTION
## ✨ What is the change?

Replace the custom Traefik Setup with our common Traefik deployment workflow.

## 📌 Reason for the change / Link to issue

hades-test.aet.cit.tum.de has a firewall that allows only specific internal IP ranges to connect to the API services on ports 80 and 443.

Therefore, the Let's Encrypt HTTP Challenge fails, leading to invalid certificates for the host.

We have a DFN ACME account, which allows us to obtain certificates without additional challenges (since the domain scope is included in our admin account permissions).
Therefore, we need a way to configure Traefik with specific ACME secrets. Since this is a common problem, we introduced the shared workflow.

We adapted the deployment to make use of the newly introduced workflow.

## 🧪 Steps for Testing

1. Merge https://github.com/ls1intum/.github/pull/56
2. Deploy this branch

## ✅ PR Checklist

- [x] I have tested these changes on hades-test.aet.cit.tum.de
- [x] Code is clean, readable, and documented


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**No user-visible changes.** This release includes internal infrastructure and deployment configuration updates to the CI/CD pipeline and Docker environment setup. End-users will not be impacted by these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->