### PR TITLE
Unify deploy-traefik and deploy pipeline jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,6 @@ jobs:
       docker-file: ./HadesScheduler/HadesOperator/Dockerfile
     secrets: inherit
 
-  deploy-traefik:
-    needs: [build-api, build-scheduler]
-    uses: ls1intum/.github/.github/workflows/deploy-docker-traefik.yml@main
-    with:
-      environment: hades-test
-      image-tag: v3.6
-    secrets: inherit
-
   build-log-manager:
     needs: [lint, build, test]
     if: github.actor != 'dependabot[bot]'
@@ -145,6 +137,79 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Checkout shared Traefik configuration
+        uses: actions/checkout@v6
+        with:
+          repository: ls1intum/.github
+          path: .github-shared
+
+      - name: Tear down existing Traefik (if present)
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          script: |
+            set -e
+            BASE_PATH="/opt/traefik"
+            COMPOSE_FILE="$BASE_PATH/docker-compose.yml"
+            if [ -f "$COMPOSE_FILE" ]; then
+              echo "$COMPOSE_FILE found."
+              docker compose -f "$COMPOSE_FILE" --env-file="$BASE_PATH/.env" down --remove-orphans --rmi all
+            else
+              echo "$COMPOSE_FILE does not exist. Skipping docker compose down."
+            fi
+
+      - name: Prepare Traefik compose and env files
+        shell: bash
+        run: |
+          cp .github-shared/traefik/docker-compose.yml docker-compose.yml
+          {
+            echo "ENVIRONMENT=hades-test"
+            echo "IMAGE_TAG=v3.6"
+            echo "HARICA_ACME_CA_SERVER=${{ secrets.HARICA_ACME_CA_SERVER }}"
+            echo "HARICA_ACME_EAB_KID=${{ secrets.HARICA_ACME_EAB_KID }}"
+            echo "HARICA_ACME_EAB_HMAC=${{ secrets.HARICA_ACME_EAB_HMAC }}"
+          } > .env
+
+      - name: Copy Traefik files to VM
+        uses: appleboy/scp-action@v1.0.0
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          timeout: 2m
+          source: "docker-compose.yml,.env"
+          target: /opt/traefik
+          strip_components: 0
+
+      - name: Bring up Traefik
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          script: |
+            set -e
+            BASE_PATH="/opt/traefik"
+            if [ ! -f "$BASE_PATH/acme.json" ]; then
+              touch "$BASE_PATH/acme.json"
+            fi
+            chmod 600 "$BASE_PATH/acme.json"
+            docker compose -f "$BASE_PATH/docker-compose.yml" --env-file="$BASE_PATH/.env" up --pull=always -d
+
       - name: Copy deployment files to VM
         uses: appleboy/scp-action@v1.0.0
         with:
@@ -155,6 +220,7 @@ jobs:
           proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          timeout: 2m
           source: "docker-compose.test.yml"
           target: /opt/hades
           strip_components: 0


### PR DESCRIPTION
## ✨ What is the change?

Unifies the two separate deployment jobs (`deploy-traefik` and `deploy`) in the CI pipeline into a single `deploy` job.

- Removes the standalone `deploy-traefik` reusable-workflow job.
- Inlines the Traefik reverse-proxy provisioning (checkout shared Traefik config, tear down existing Traefik, copy compose + HARICA `.env` to the VM, bring Traefik up) as steps that run **before** the app deploy.
- Sets a `2m` timeout on the `scp` tasks.

## 📌 Reason for the change / Link to issue

Repo cleanup. The pipeline previously ran `deploy-traefik` (a reusable workflow provisioning the Traefik proxy) and `deploy` (the app deploy) as two separate jobs **in parallel**, both targeting `hades-test`. Because the app's `docker-compose.test.yml` attaches to the external `traefik` network that `deploy-traefik` creates, running them in parallel risked a race where the app deploy could start before the `traefik` network existed.

Folding Traefik provisioning into the single `deploy` job makes the ordering deterministic (Traefik is up before the app deploys) and leaves one job to reason about.

## 🧪 Steps for Testing

1. Trigger the CI pipeline (push to a branch / `workflow_dispatch`).
2. Confirm the `deploy-traefik` job no longer exists and a single `deploy` job runs.
3. Confirm the `deploy` job provisions Traefik first, then deploys the Hades services, and that the `traefik` network is present when the app comes up.
4. Confirm the `scp` steps honor the 2m timeout.

> Note: successful deployment also requires the `hades-test` VM to be reachable from the deployment gateway (unrelated infra prerequisite).

## ✅ PR Checklist

- [ ] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation to manage Traefik directly on the remote server.
  * Added steps to prepare configuration and environment files, initialize certificate storage, and start the deployment.
  * Increased the deployment file upload timeout to two minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->