### PR TITLE
Add HadesLogManager to Helm chart and optional API auth

### DIFF
--- a/helm/hades/Readme.md
+++ b/helm/hades/Readme.md
@@ -65,7 +65,7 @@ The Scheduler operates in **`operator` mode** by default (`hadesScheduler.config
     ```bash
     helm upgrade --install hades ./helm/hades -n hades --create-namespace \
       --set ingress.host=hades.example.com \
-      --set tls.secretName=my-secrect
+      --set ingress.tls.secretName=my-secret
     ```
 
 > In the above command:

--- a/helm/hades/templates/hades-api-deployment.yaml
+++ b/helm/hades/templates/hades-api-deployment.yaml
@@ -48,6 +48,6 @@ spec:
             - name: AUTH_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.hadesApi.authKeySecret }}
+                  name: {{ .Values.hadesApi.authKeySecret | quote }}
                   key: AUTH_KEY
             {{- end }}

--- a/helm/hades/templates/hades-api-deployment.yaml
+++ b/helm/hades/templates/hades-api-deployment.yaml
@@ -44,3 +44,10 @@ spec:
           env:
             - name: NATS_URL
               value: "nats://{{ .Values.nats.host }}:{{ .Values.nats.port }}"
+            {{- if .Values.hadesApi.authKeySecret }}
+            - name: AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.hadesApi.authKeySecret }}
+                  key: AUTH_KEY
+            {{- end }}

--- a/helm/hades/templates/hades-log-manager-deployment.yaml
+++ b/helm/hades/templates/hades-log-manager-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "hades-log-manager"
+spec:
+  replicas: {{ .Values.hadesLogManager.replicaCount }}
+  selector:
+    matchLabels:
+      app: hades-log-manager-selector
+  template:
+    metadata:
+      labels:
+        app: hades-log-manager-selector
+    spec:
+      containers:
+        - name: "hades-log-manager"
+          image: "{{ .Values.hadesLogManager.image.repository }}:{{ .Values.hadesLogManager.image.tag }}"
+          imagePullPolicy: {{ .Values.hadesLogManager.image.pullPolicy }}
+          resources:
+            limits:
+              cpu: {{ .Values.hadesLogManager.resources.limits.cpu | quote }}
+              memory: {{ .Values.hadesLogManager.resources.limits.memory | quote }}
+            requests:
+              cpu: {{ .Values.hadesLogManager.resources.requests.cpu | quote }}
+              memory: {{ .Values.hadesLogManager.resources.requests.memory | quote }}
+          ports:
+            - containerPort: {{ .Values.hadesLogManager.service.targetPort }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.hadesLogManager.service.targetPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.hadesLogManager.service.targetPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          env:
+            - name: NATS_URL
+              value: "nats://{{ .Values.nats.host }}:{{ .Values.nats.port }}"
+            - name: HADESLOGMANAGER_API_PORT
+              value: {{ .Values.hadesLogManager.service.targetPort | quote }}
+            {{- if .Values.hadesLogManager.artemisAdapterUrl }}
+            - name: ARTEMIS_ADAPTER_URL
+              value: {{ .Values.hadesLogManager.artemisAdapterUrl | quote }}
+            {{- end }}

--- a/helm/hades/templates/hades-log-manager-service.yaml
+++ b/helm/hades/templates/hades-log-manager-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "hades-log-manager-service"
+spec:
+  selector:
+    app: hades-log-manager-selector
+  ports:
+    - port: {{ .Values.hadesLogManager.service.port }}
+      targetPort: {{ .Values.hadesLogManager.service.targetPort }}
+      protocol: TCP
+  type: {{ .Values.hadesLogManager.service.type }}

--- a/helm/hades/values.yaml
+++ b/helm/hades/values.yaml
@@ -72,6 +72,9 @@ hadesLogManager:
     type: ClusterIP
     port: 8081
     targetPort: 8081
+  # Keep at 1: the log manager aggregates per-job logs in memory and uses plain
+  # (non-queue, non-durable) NATS subscriptions, so multiple replicas would
+  # independently forward duplicate/split logs to the Artemis adapter.
   replicaCount: 1
   resources:
     limits:

--- a/helm/hades/values.yaml
+++ b/helm/hades/values.yaml
@@ -15,6 +15,9 @@ hadesApi:
     requests:
       cpu: "200m"
       memory: "256Mi"
+  # Name of an existing Secret holding key AUTH_KEY to protect the /build endpoint.
+  # Empty = no auth (endpoint is open).
+  authKeySecret: ""
 
 hadesScheduler:
   image:
@@ -59,6 +62,26 @@ hadesOperator:
   targetNamespace: ""
   DeleteOnComplete: true
   maxParallelism: "100"
+
+hadesLogManager:
+  image:
+    repository: ghcr.io/ls1intum/hades/hades-log-manager
+    tag: latest
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+    port: 8081
+    targetPort: 8081
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+  # External Artemis adapter endpoint the log manager forwards aggregated job logs to.
+  artemisAdapterUrl: "http://hades-artemis-adapter.hades-artemis-connector.svc.cluster.local:8082/adapter/logs"
 
 rbac:
   hadesScheduler:


### PR DESCRIPTION
## Summary
- Adds a `hades-log-manager` Deployment + Service and a `hadesLogManager` values block, so the log adapter deploys alongside the API, scheduler, and operator. It runs cluster-internal (ClusterIP), consumes build-job logs from NATS, and forwards them to the Artemis adapter via `ARTEMIS_ADAPTER_URL`. This closes the gap noted in the repo README (log manager previously not part of the Helm deployment).
- Wires an optional `AUTH_KEY` (HTTP Basic Auth, user `hades`) into `hades-api`, gated on `hadesApi.authKeySecret` so behaviour is unchanged when unset.
- Fixes the `--set ingress.tls.secretName` example in the chart Readme.

## Testing
Deployed to the `stud-cp` cluster (namespace `hades`) at host `hades.stud.k8s.aet.cit.tum.de`:
- All pods Running/Ready (api, scheduler, operator, log-manager, nats).
- Scheduler connected to NATS in operator mode; operator watches `BuildJob`; log manager subscribed to NATS and serving `/health`.
- Ingress + Let's Encrypt TLS (`hades-tls`) issued; `/build` enforces Basic Auth (401 without/with wrong creds, reaches handler with valid creds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Helm deployment support for the Hades Log Manager, including configurable replicas, resources, networking, health checks, and optional Artemis integration.
  - Added configurable service exposure for the Log Manager.
  - Added optional API authentication through a Kubernetes secret.

- **Bug Fixes**
  - Updated the Quick Start Helm command to use the current ingress TLS secret configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->