### PR TITLE
Add a chart-wide debug toggle

### DIFF
--- a/helm/hades/templates/hades-api-deployment.yaml
+++ b/helm/hades/templates/hades-api-deployment.yaml
@@ -42,6 +42,8 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           env:
+            - name: DEBUG
+              value: {{ .Values.debug | quote }}
             - name: NATS_URL
               value: "nats://{{ .Values.nats.host }}:{{ .Values.nats.port }}"
             {{- if .Values.hadesApi.authKeySecret }}

--- a/helm/hades/templates/hades-log-manager-deployment.yaml
+++ b/helm/hades/templates/hades-log-manager-deployment.yaml
@@ -42,6 +42,8 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           env:
+            - name: DEBUG
+              value: {{ .Values.debug | quote }}
             - name: NATS_URL
               value: "nats://{{ .Values.nats.host }}:{{ .Values.nats.port }}"
             - name: HADESLOGMANAGER_API_PORT

--- a/helm/hades/templates/hades-operator-deployment.yaml
+++ b/helm/hades/templates/hades-operator-deployment.yaml
@@ -34,6 +34,12 @@ spec:
               containerPort: 8081
 
           env:
+            - name: DEBUG
+              value: {{ .Values.debug | quote }}
+            # The operator's log verbosity is controlled by controller-runtime's
+            # DEV_MODE; wire it to the same toggle so debug mode is effective here.
+            - name: DEV_MODE
+              value: {{ .Values.debug | quote }}
             - name: NATS_URL
               value: "nats://{{ .Values.nats.host }}:{{ .Values.nats.port }}"
             {{- if not .Values.hadesOperator.clusterWide }}

--- a/helm/hades/templates/hades-scheduler-deployment.yaml
+++ b/helm/hades/templates/hades-scheduler-deployment.yaml
@@ -27,6 +27,8 @@ spec:
           ports:
             - containerPort: {{ .Values.hadesScheduler.service.targetPort }}
           env:
+            - name: DEBUG
+              value: {{ .Values.debug | quote }}
             - name: NATS_URL
               value: "nats://{{ .Values.nats.host }}:{{ .Values.nats.port }}"
             - name: HADES_EXECUTOR

--- a/helm/hades/values.yaml
+++ b/helm/hades/values.yaml
@@ -1,3 +1,7 @@
+# Global debug switch. When true, every Hades container gets DEBUG=true
+# (and the operator additionally gets DEV_MODE=true) for verbose logging.
+debug: false
+
 hadesApi:
   image:
     repository: ghcr.io/ls1intum/hades/hades-api


### PR DESCRIPTION
## ✨ What is the change?

Adds a chart-wide `debug` toggle to the Hades Helm chart.

- New top-level value `debug` (default `false`).
- When set, every Hades container (`hades-api`, `hades-scheduler`, `hades-operator`, `hades-log-manager`) receives `DEBUG=true`.
- The operator additionally receives `DEV_MODE=true`, because its log verbosity is driven by controller-runtime's `DEV_MODE`, not `DEBUG`.

Enable with:
```bash
helm upgrade hades ./helm/hades -n hades --set debug=true
```

## 📌 Reason for the change / Link to issue

Makes it a one-flag operation to turn on verbose logging across the whole stack for debugging deployed instances, instead of editing each deployment's env by hand.

## 🧪 Steps for Testing

1. `helm template hades ./helm/hades` → each app container has `DEBUG` with value `"false"`; operator also has `DEV_MODE` `"false"`.
2. `helm template hades ./helm/hades --set debug=true` → the same envs render `"true"`.
3. `helm lint ./helm/hades` passes.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global Helm debug setting, disabled by default.
  * Enabling debug mode activates debug logging across Hades services.
  * The operator also enables development mode when debugging is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->