### PR TITLE
Fix continueOnError for k8s init-container steps under set -e

### DIFF
--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_build_test.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_build_test.go
@@ -1,0 +1,69 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	buildv1 "github.com/ls1intum/hades/HadesScheduler/HadesOperator/api/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func initContainer(t *testing.T, job *batchv1.Job, name string) corev1.Container {
+	t.Helper()
+	for _, c := range job.Spec.Template.Spec.InitContainers {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("init container %q not found", name)
+	return corev1.Container{}
+}
+
+func envValue(c corev1.Container, name string) (string, bool) {
+	for _, e := range c.Env {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+// A continueOnError step must not abort the pod: its init container has to exit 0
+// even when the script uses `set -e` or an explicit non-zero exit, so later steps
+// (e.g. the result parser) still run. A normal step must keep failing on error.
+func TestBuildK8sJob_ContinueOnError(t *testing.T) {
+	failingScript := "set -e; ./gradlew test"
+	bj := &buildv1.BuildJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1"},
+		Spec: buildv1.BuildJobSpec{
+			Name: "job-1",
+			Steps: []buildv1.BuildStep{
+				{ID: 1, Name: "clone", Image: "alpine", Script: "echo clone"},
+				{ID: 2, Name: "test", Image: "alpine", Script: failingScript, ContinueOnError: true},
+			},
+		},
+	}
+
+	job := buildK8sJob(bj, "job-1", true, false)
+
+	// Normal step: run the script directly so a failure fails the container.
+	normal := initContainer(t, job, fmt.Sprintf(BuildStepPrefix, 1))
+	if len(normal.Args) != 1 || normal.Args[0] != "echo clone" {
+		t.Errorf("normal step args = %v, want [\"echo clone\"]", normal.Args)
+	}
+	if _, ok := envValue(normal, "HADES_STEP_SCRIPT"); ok {
+		t.Errorf("normal step should not set HADES_STEP_SCRIPT")
+	}
+
+	// continueOnError step: script runs in a nested shell whose status is ignored.
+	coe := initContainer(t, job, fmt.Sprintf(BuildStepPrefix, 2))
+	wantArgs := `/bin/sh -c "$HADES_STEP_SCRIPT" || true`
+	if len(coe.Args) != 1 || coe.Args[0] != wantArgs {
+		t.Errorf("continueOnError step args = %v, want [%q]", coe.Args, wantArgs)
+	}
+	if got, ok := envValue(coe, "HADES_STEP_SCRIPT"); !ok || got != failingScript {
+		t.Errorf("continueOnError step HADES_STEP_SCRIPT = %q (present=%v), want %q", got, ok, failingScript)
+	}
+}

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
@@ -351,7 +351,16 @@ func buildK8sJob(bj *buildv1.BuildJob, jobName string, deleteOnComplete bool, su
 		if strings.TrimSpace(s.Script) != "" {
 			c.Command = []string{"/bin/sh", "-c"}
 			if s.ContinueOnError {
-				c.Args = []string{s.Script + "; exit 0"}
+				// Init containers have no native "continue on error": a non-zero
+				// exit aborts the pod and skips the remaining steps. Run the
+				// script in a nested shell whose exit status is discarded (|| true)
+				// so this container always exits 0 and later steps (e.g. the
+				// result parser) still run. This is robust even when the script
+				// uses `set -e` or ends in an explicit non-zero `exit`, both of
+				// which would bypass a naive "<script>; exit 0". The script is
+				// passed via an env var to avoid shell-quoting issues.
+				c.Env = append(c.Env, corev1.EnvVar{Name: "HADES_STEP_SCRIPT", Value: s.Script})
+				c.Args = []string{`/bin/sh -c "$HADES_STEP_SCRIPT" || true`}
 			} else {
 				c.Args = []string{s.Script}
 			}


### PR DESCRIPTION
## ✨ What is the change?

Makes `continueOnError` robust for the Kubernetes (operator) executor.

The operator runs each build step as a sequential **init container**. Init containers have no native "continue on error" - a non-zero exit aborts the pod and skips the remaining steps. For a `continueOnError` step the operator appended `; exit 0` to the script. That works for a bare failing command (e.g. `./gradlew test`), but is **bypassed** when the script uses `set -e` (the shell exits on the failing command before reaching `; exit 0`) or ends in an explicit non-zero `exit`.

When that happens, the Execute init container fails, Kubernetes aborts the pod, and later steps - notably the **result parser** that posts test outcomes to Artemis - never run. So a submission that fails any test produces no result.

**Fix:** run `continueOnError` scripts in a nested shell whose exit status is discarded:
```
/bin/sh -c "$HADES_STEP_SCRIPT" || true
```
The script is passed via an env var (`HADES_STEP_SCRIPT`) to avoid shell-quoting issues. This always exits 0 - robust to `set -e` and explicit non-zero exits - so subsequent steps still run. Normal (non-`continueOnError`) steps are unchanged and still fail the pod on error.

The build "success/failure" of a submission is determined by the parsed test results sent to Artemis, not by the container exit code, so tolerating the Execute step's non-zero exit is correct (this matches the Docker executor's behavior).

## 📌 Reason for the change / Link to issue

Reported: with the k8s executor, `./gradlew test` failing (normal for a submission that doesn't pass every test) aborted the pod before the Parse-Result step, so results were never posted. Artemis correctly sets `continue_on_error: true` on the Execute step; the operator honored it only for scripts without `set -e`/explicit exit.

## 🧪 Steps for Testing

Verified empirically on a cluster:
- `set -e; echo running; false` step with `continueOnError: true` **before** this change → pod failed at that step, next step never ran, job marked Failed.
- After this change → the step's init container exits 0 and the following step runs.

Also:
- Added a unit test (`buildjob_build_test.go`) asserting the container args/env for both a normal and a `continueOnError` step (the operator module's first unit test).
- `go build`, `go vet`, `go test`, `gofmt` all pass.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Steps configured to continue after errors now reliably proceed even when scripts use strict error handling or return a nonzero status.
  * Improved handling ensures failed scripts do not prevent subsequent steps from running.

* **Tests**
  * Added coverage verifying normal and continue-on-error step behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->