### PR TITLE
Publish the Helm chart to GHCR (OCI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,15 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      # Chart-only changes are handled by release-chart.yml; don't also run the
+      # full build/test/deploy pipeline here (one trigger per target).
+      - "helm/**"
   pull_request:
     branches:
       - main
     paths-ignore:
       - "**.md"
+      - "helm/**"
   release:
     types: [released, prereleased]
   workflow_dispatch:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,52 @@
+name: Release Helm Chart
+
+# Packages the Helm chart, publishes it as a GitHub Release, and updates the
+# Helm repository index on the gh-pages branch. A new release is cut only when
+# helm/hades/Chart.yaml's `version` changes.
+#
+# One-time setup (repo admin): enable GitHub Pages with the source set to the
+# `gh-pages` branch (Settings -> Pages). The chart is then installable via:
+#   helm repo add hades https://ls1intum.github.io/hades
+#   helm install hades hades/hades -n hades --create-namespace
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "helm/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write # create releases and push to gh-pages
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      # chart-releaser packages with `helm package`, which needs the subchart
+      # (nats) vendored into charts/. Add the repo and build the dependency.
+      - name: Vendor chart dependencies
+        run: |
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+          helm dependency build helm/hades
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: helm
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,8 +1,8 @@
 name: Release Helm Chart
 
-# Packages the Helm chart and pushes it to GHCR as an OCI artifact (alongside
-# the Docker images). A new version is published only when
-# helm/hades/Chart.yaml's `version` changes. Install with:
+# Validates the Helm chart on pull requests, and on pushes to main publishes it
+# to GHCR as an OCI artifact (alongside the Docker images). A new version is
+# published only when helm/hades/Chart.yaml's `version` changes. Install with:
 #   helm install hades oci://ghcr.io/ls1intum/charts/hades --version <version> \
 #     -n hades --create-namespace
 #
@@ -14,15 +14,42 @@ on:
       - main
     paths:
       - "helm/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "helm/**"
   workflow_dispatch:
 
 permissions:
   contents: read
-  packages: write # push the chart to GHCR
 
 jobs:
-  release:
+  # Runs on chart pull requests so a broken chart can't be published on merge.
+  validate:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint and template
+        run: |
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+          helm dependency build helm/hades
+          helm lint helm/hades
+          helm template hades helm/hades > /dev/null
+
+  # Publishes only on pushes to main (and manual dispatch), never on PRs.
+  release:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the chart to GHCR
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,13 +1,12 @@
 name: Release Helm Chart
 
-# Packages the Helm chart, publishes it as a GitHub Release, and updates the
-# Helm repository index on the gh-pages branch. A new release is cut only when
-# helm/hades/Chart.yaml's `version` changes.
+# Packages the Helm chart and pushes it to GHCR as an OCI artifact (alongside
+# the Docker images). A new version is published only when
+# helm/hades/Chart.yaml's `version` changes. Install with:
+#   helm install hades oci://ghcr.io/ls1intum/charts/hades --version <version> \
+#     -n hades --create-namespace
 #
-# One-time setup (repo admin): enable GitHub Pages with the source set to the
-# `gh-pages` branch (Settings -> Pages). The chart is then installable via:
-#   helm repo add hades https://ls1intum.github.io/hades
-#   helm install hades hades/hades -n hades --create-namespace
+# The chart lives in GHCR, so this does not touch GitHub Pages (used for docs).
 
 on:
   push:
@@ -18,7 +17,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write # create releases and push to gh-pages
+  contents: read
+  packages: write # push the chart to GHCR
 
 jobs:
   release:
@@ -26,27 +26,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
         uses: azure/setup-helm@v4
 
-      # chart-releaser packages with `helm package`, which needs the subchart
-      # (nats) vendored into charts/. Add the repo and build the dependency.
-      - name: Vendor chart dependencies
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Package and push chart
         run: |
+          set -euo pipefail
+          version=$(helm show chart helm/hades | awk '/^version:/{print $2}')
+
+          # Skip if this version is already published so unrelated helm/**
+          # changes don't overwrite a released chart.
+          if helm show chart "oci://ghcr.io/ls1intum/charts/hades" --version "$version" >/dev/null 2>&1; then
+            echo "hades $version is already published to GHCR; nothing to do."
+            exit 0
+          fi
+
           helm repo add nats https://nats-io.github.io/k8s/helm/charts/
           helm dependency build helm/hades
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
-        with:
-          charts_dir: helm
-        env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          helm package helm/hades --destination dist
+          helm push "dist/hades-${version}.tgz" "oci://ghcr.io/ls1intum/charts"

--- a/Readme.md
+++ b/Readme.md
@@ -242,6 +242,39 @@ For production deployments in a VM:
 Hades includes Ansible playbooks for automated deployment.
 See the `ansible/hades/README.md` file for more details.
 
+### Releasing the Helm Chart
+
+The chart is published to GHCR as an OCI artifact by
+`.github/workflows/release-chart.yml`. It runs on pushes to `main` that touch
+`helm/**` (or via `workflow_dispatch`) and publishes to
+`oci://ghcr.io/ls1intum/charts/hades`.
+
+Checklist when cutting a chart release:
+
+1. **Bump `version` in `helm/hades/Chart.yaml`** (SemVer). This is the single
+   source of truth: the workflow **only publishes when the version does not
+   already exist** in GHCR, so a change to `helm/**` without a version bump is a
+   no-op. Never re-tag an already-published version - always bump.
+2. **Update `appVersion`** if the deployed application changed (it tracks the
+   app, not the chart, and does not need to follow SemVer).
+3. **CRDs are not upgraded by Helm.** Files under `helm/hades/crds/` are only
+   applied on first install and never on `helm upgrade`. If a release changes
+   the `BuildJob` CRD, bump the chart version, note it in the release, and apply
+   the CRD manually on existing clusters:
+   `kubectl apply -f helm/hades/crds/build.hades.tum.de_buildjobs.yaml`.
+4. **Subchart dependencies** (currently `nats`): if you change a dependency
+   version in `Chart.yaml`, run `helm dependency update helm/hades` and commit
+   the updated `Chart.lock`. CI vendors the subchart at package time; the
+   `charts/` directory itself is not committed.
+5. **Validate before merging**: `helm lint helm/hades`,
+   `helm template helm/hades`, and ideally a throwaway
+   `helm install` in a scratch namespace.
+6. **Package visibility**: the GHCR chart package must be **public** for
+   anonymous `helm install` (same as the container images). Set once in the org
+   Packages settings after the first publish.
+7. **Keep the install snippet in sync**: update the `--version` in the
+   Kubernetes install instructions above when you cut a new version.
+
 ## Dependency Management
 
 Hades uses [Renovate](https://docs.renovatebot.com/) (configured in `renovate.json`) to open automated PRs for dependency updates across Go modules, Helm charts, Docker base images, and GitHub Actions.

--- a/Readme.md
+++ b/Readme.md
@@ -100,11 +100,23 @@ For production deployments, Hades is designed to run natively within a Kubernete
 2. **Deployment**: We provide a comprehensive Helm Chart that packages the API, Scheduler, Operator, and NATS broker. By default the scheduler runs in `operator` mode, delegating job lifecycle management to the HadesOperator via `BuildJob` custom resources.
    
    ```fish
-   # Quick install
+   # Install from the published Helm repository (recommended)
+   helm repo add hades https://ls1intum.github.io/hades
+   helm repo update
+   helm upgrade --install hades hades/hades -n hades --create-namespace
+   ```
+
+   Or install from a local checkout of this repository:
+
+   ```fish
    helm repo add nats https://nats-io.github.io/k8s/helm/charts
    helm dependency build ./helm/hades/
    helm upgrade --install hades ./helm/hades -n hades --create-namespace
    ```
+
+   > **Note:** Helm does not upgrade CRDs after the first install. When a release
+   > changes the `BuildJob` CRD, apply it manually:
+   > `kubectl apply -f https://raw.githubusercontent.com/ls1intum/hades/main/helm/hades/crds/build.hades.tum.de_buildjobs.yaml`
 
 3. **Detailed Documentation**: For advanced configuration (Ingress, TLS, resource limits) and step-by-step setup, please refer to the: [Hades Helm Chart Guide](./helm/hades/Readme.md)
 

--- a/Readme.md
+++ b/Readme.md
@@ -100,10 +100,9 @@ For production deployments, Hades is designed to run natively within a Kubernete
 2. **Deployment**: We provide a comprehensive Helm Chart that packages the API, Scheduler, Operator, and NATS broker. By default the scheduler runs in `operator` mode, delegating job lifecycle management to the HadesOperator via `BuildJob` custom resources.
    
    ```fish
-   # Install from the published Helm repository (recommended)
-   helm repo add hades https://ls1intum.github.io/hades
-   helm repo update
-   helm upgrade --install hades hades/hades -n hades --create-namespace
+   # Install the published chart from GHCR (recommended)
+   helm upgrade --install hades oci://ghcr.io/ls1intum/charts/hades \
+     --version 0.2.0 -n hades --create-namespace
    ```
 
    Or install from a local checkout of this repository:

--- a/Readme.md
+++ b/Readme.md
@@ -114,8 +114,9 @@ For production deployments, Hades is designed to run natively within a Kubernete
    ```
 
    > **Note:** Helm does not upgrade CRDs after the first install. When a release
-   > changes the `BuildJob` CRD, apply it manually:
-   > `kubectl apply -f https://raw.githubusercontent.com/ls1intum/hades/main/helm/hades/crds/build.hades.tum.de_buildjobs.yaml`
+   > changes the `BuildJob` CRD, apply it manually from the same chart version you
+   > installed (not from the mutable `main` branch):
+   > `helm show crds oci://ghcr.io/ls1intum/charts/hades --version 0.2.0 | kubectl apply -f -`
 
 3. **Detailed Documentation**: For advanced configuration (Ingress, TLS, resource limits) and step-by-step setup, please refer to the: [Hades Helm Chart Guide](./helm/hades/Readme.md)
 
@@ -259,9 +260,9 @@ Checklist when cutting a chart release:
    app, not the chart, and does not need to follow SemVer).
 3. **CRDs are not upgraded by Helm.** Files under `helm/hades/crds/` are only
    applied on first install and never on `helm upgrade`. If a release changes
-   the `BuildJob` CRD, bump the chart version, note it in the release, and apply
-   the CRD manually on existing clusters:
-   `kubectl apply -f helm/hades/crds/build.hades.tum.de_buildjobs.yaml`.
+   the `BuildJob` CRD, bump the chart version, note it in the release, and tell
+   users to apply the CRD from the matching chart version on existing clusters:
+   `helm show crds oci://ghcr.io/ls1intum/charts/hades --version <version> | kubectl apply -f -`.
 4. **Subchart dependencies** (currently `nats`): if you change a dependency
    version in `Chart.yaml`, run `helm dependency update helm/hades` and commit
    the updated `Chart.lock`. CI vendors the subchart at package time; the

--- a/helm/hades/Chart.yaml
+++ b/helm/hades/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## ✨ What is the change?

Adds a workflow that publishes the Helm chart to **GHCR as an OCI artifact** (alongside the Docker images), and bumps the chart to **0.2.0**.

- **`.github/workflows/release-chart.yml`**: on pushes to `main` touching `helm/**` (or `workflow_dispatch`), it logs in to GHCR, vendors the `nats` subchart, packages the chart, and `helm push`es it to `oci://ghcr.io/ls1intum/charts`. It **skips** if the current `Chart.yaml` version is already published, so unrelated `helm/**` changes don't overwrite a release.
- `Chart.yaml` version `0.1.0 → 0.2.0` so merging cuts the first publish.
- README updated with the OCI install command and the manual CRD-upgrade note.

Install once published:
```bash
helm upgrade --install hades oci://ghcr.io/ls1intum/charts/hades \
  --version 0.2.0 -n hades --create-namespace
```

## 📌 Why OCI instead of a gh-pages Helm repo?

This repo's **GitHub Pages is used for the documentation site** (`build_type: workflow`). A `chart-releaser`/`gh-pages`-branch Helm repo can't coexist with that - Pages serves a single source, and with an Actions-based deployment a `gh-pages` branch isn't served at all. Publishing to GHCR keeps Pages 100% for docs and reuses the existing container registry and `GITHUB_TOKEN` (no extra infra, no `helm repo add`).

## ⚙️ One-time setup

Uses the built-in `GITHUB_TOKEN`. The **chart package's visibility in GHCR** must be **public** for anonymous `helm install` (same as the Docker images). The first push creates `ghcr.io/ls1intum/charts/hades`; set it to public in the org's Packages settings if it isn't inherited.

## 🧪 Steps for Testing

- `helm lint helm/hades` passes; `helm package helm/hades` → `hades-0.2.0.tgz`.
- Workflow YAML validated.
- After merge: the workflow publishes `oci://ghcr.io/ls1intum/charts/hades:0.2.0`; `helm show chart oci://ghcr.io/ls1intum/charts/hades --version 0.2.0` resolves, and the install command above works.

## Notes

- CRD caveat: Helm never upgrades CRDs from `crds/` after first install; README documents applying the CRD manually on upgrade.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Documentation updated (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm charts are now automatically packaged and published as OCI artifacts to GitHub Container Registry.
  * Added safeguards to skip publishing chart versions that already exist.
* **Documentation**
  * Updated Kubernetes installation instructions to use the published chart.
  * Added guidance for local installation, CRD updates, dependency changes, and chart releases.
* **Chores**
  * CI now skips chart-only changes.
  * Updated the Helm chart version to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->