### PR TITLE
Publish all step logs before deleting completed BuildJobs

### DIFF
--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_containers.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_containers.go
@@ -90,31 +90,35 @@ func allTerminatedLogsPublished(pod *corev1.Pod, statuses []buildv1.ContainerSta
 }
 
 // logsDrained reports whether all terminated containers of the BuildJob's pod have
-// had their logs published. podGone is true when the pod can no longer be found
-// (its logs are unrecoverable), so the caller should proceed to delete rather than
-// requeue forever.
+// had their logs published. podGone is true only when the pod is confirmed gone
+// (a NotFound result), so the caller proceeds to delete rather than requeue; any
+// other error is returned so the caller retries instead of deleting and losing
+// logs.
 func (r *BuildJobReconciler) logsDrained(ctx context.Context, bj *buildv1.BuildJob) (drained bool, podGone bool, err error) {
-	pl := r.podLogReader(bj.Namespace, bj.Name)
+	// Re-read the latest status: updateContainerStatuses (run earlier in this
+	// reconcile) records the pod name and the freshest LogsPublished flags on a
+	// separately fetched object.
+	var fresh buildv1.BuildJob
+	if err := r.Get(ctx, client.ObjectKeyFromObject(bj), &fresh); err != nil {
+		return false, false, err
+	}
 
-	podName, err := pl.ResolvePodName(ctx)
-	if err != nil {
-		// The pod cannot be resolved anymore; treat it as gone so we do not
-		// requeue forever waiting for logs that can no longer be read.
-		return false, true, nil
+	podName := fresh.Status.PodName
+	if podName == "" {
+		// The pod name has not been recorded yet, so we cannot confirm the pod is
+		// gone. Do not delete; let the caller requeue (the drain timeout is the
+		// backstop against waiting forever).
+		return false, false, nil
 	}
 
 	p, err := r.K8sClient.CoreV1().Pods(bj.Namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// The pod is confirmed gone; its logs are unrecoverable.
 			return false, true, nil
 		}
-		return false, false, err
-	}
-
-	// updateContainerStatuses writes status onto a separately fetched object, so
-	// re-read the latest ContainerStatuses to see the freshest LogsPublished flags.
-	var fresh buildv1.BuildJob
-	if err := r.Get(ctx, client.ObjectKeyFromObject(bj), &fresh); err != nil {
+		// Transient/API/authorization error: propagate so the caller retries
+		// instead of deleting the BuildJob and losing logs.
 		return false, false, err
 	}
 

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_containers.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_containers.go
@@ -8,6 +8,7 @@ import (
 	buildv1 "github.com/ls1intum/hades/HadesScheduler/HadesOperator/api/v1"
 	"github.com/ls1intum/hades/hadesScheduler/k8s"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,6 +59,66 @@ func (r *BuildJobReconciler) initializeContainerStatuses(ctx context.Context, bj
 		fresh.Status.CurrentStep = &currentStep
 		return r.Status().Update(ctx, &fresh)
 	})
+}
+
+// allTerminatedLogsPublished reports whether every container that has reached a
+// terminal state in the pod has had its logs published in the BuildJob status.
+// It is the drain gate used before deleting a completed BuildJob: only containers
+// that actually terminated (Succeeded/Failed) must be published. Containers that
+// never ran (e.g. init steps after a failing step, or the finalizer on a failed
+// job) have no terminated state and therefore do not block deletion. A terminated
+// container without a matching, published status entry counts as not-yet-drained.
+func allTerminatedLogsPublished(pod *corev1.Pod, statuses []buildv1.ContainerStatus) bool {
+	published := make(map[string]bool, len(statuses))
+	for _, cs := range statuses {
+		published[cs.Name] = cs.LogsPublished
+	}
+
+	drained := func(containerStatuses []corev1.ContainerStatus) bool {
+		for _, cs := range containerStatuses {
+			if cs.State.Terminated == nil {
+				continue
+			}
+			if !published[cs.Name] {
+				return false
+			}
+		}
+		return true
+	}
+
+	return drained(pod.Status.InitContainerStatuses) && drained(pod.Status.ContainerStatuses)
+}
+
+// logsDrained reports whether all terminated containers of the BuildJob's pod have
+// had their logs published. podGone is true when the pod can no longer be found
+// (its logs are unrecoverable), so the caller should proceed to delete rather than
+// requeue forever.
+func (r *BuildJobReconciler) logsDrained(ctx context.Context, bj *buildv1.BuildJob) (drained bool, podGone bool, err error) {
+	pl := r.podLogReader(bj.Namespace, bj.Name)
+
+	podName, err := pl.ResolvePodName(ctx)
+	if err != nil {
+		// The pod cannot be resolved anymore; treat it as gone so we do not
+		// requeue forever waiting for logs that can no longer be read.
+		return false, true, nil
+	}
+
+	p, err := r.K8sClient.CoreV1().Pods(bj.Namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, true, nil
+		}
+		return false, false, err
+	}
+
+	// updateContainerStatuses writes status onto a separately fetched object, so
+	// re-read the latest ContainerStatuses to see the freshest LogsPublished flags.
+	var fresh buildv1.BuildJob
+	if err := r.Get(ctx, client.ObjectKeyFromObject(bj), &fresh); err != nil {
+		return false, false, err
+	}
+
+	return allTerminatedLogsPublished(p, fresh.Status.ContainerStatuses), false, nil
 }
 
 // updateContainerStatuses resolves PodName using the BuildJob and updates each BuildJob's container statuses accordingly

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
@@ -51,6 +51,15 @@ const BuildStepPrefix = "step-%d"
 
 const requeueDelay = 2 * time.Second
 
+// logDrainRequeueDelay is how long to wait before re-reconciling a completed
+// BuildJob whose terminated containers still have unpublished logs.
+const logDrainRequeueDelay = 1 * time.Second
+
+// logDrainTimeout bounds how long the operator keeps requeuing to drain logs
+// before it deletes a completed BuildJob anyway, to avoid an infinite requeue
+// when logs can never be published.
+const logDrainTimeout = 45 * time.Second
+
 const defaultPriority = 1
 
 const (
@@ -124,6 +133,31 @@ func (r *BuildJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// Job already exists, check the status of the job
 		done, succeeded, msg := jobFinished(&existingJob)
 		if done {
+
+			// Drain gate: when the CR (and thus the pod) will be deleted on
+			// completion, all logs of terminated containers must be published
+			// first, because Kubernetes only serves container logs while the pod
+			// exists. This runs BEFORE setStatusCompleted on purpose: setting the
+			// terminal phase would trip the early-return guard at the top of
+			// Reconcile, so we keep the phase non-terminal and requeue until the
+			// logs are drained (or a safety valve fires).
+			if r.DeleteOnComplete {
+				drained, podGone, drainErr := r.logsDrained(ctx, &bj)
+				timedOut := time.Since(jobCompletionTime(&existingJob)) > logDrainTimeout
+
+				if drainErr != nil && !timedOut {
+					return ctrl.Result{}, drainErr
+				}
+				if drainErr == nil && !drained && !podGone && !timedOut {
+					slog.Info("Waiting for terminated container logs to be published before deleting", "buildJob", bj.Name)
+					return ctrl.Result{RequeueAfter: logDrainRequeueDelay}, nil
+				}
+				if podGone && !drained {
+					slog.Warn("Pod gone before all logs were drained; deleting anyway", "buildJob", bj.Name)
+				} else if timedOut && !drained {
+					slog.Warn("Timed out waiting for logs to drain; deleting anyway", "buildJob", bj.Name)
+				}
+			}
 
 			if err := r.setStatusCompleted(ctx, req.NamespacedName, bj.Name, succeeded, msg); err != nil {
 				if apierrors.IsConflict(err) {
@@ -498,6 +532,32 @@ func jobFinished(k8sJob *batchv1.Job) (done bool, succeeded bool, reason string)
 		}
 	}
 	return false, false, ""
+}
+
+// jobCompletionTime returns a best-effort timestamp for when the Job finished.
+// It prefers Status.CompletionTime (set for completed Jobs), falls back to the
+// latest true Complete/Failed condition transition time (failed Jobs have no
+// CompletionTime), and finally to now() when nothing is available so callers do
+// not treat an unknown completion time as already timed out.
+func jobCompletionTime(k8sJob *batchv1.Job) time.Time {
+	if k8sJob.Status.CompletionTime != nil {
+		return k8sJob.Status.CompletionTime.Time
+	}
+	var latest time.Time
+	for _, c := range k8sJob.Status.Conditions {
+		if c.Status != corev1.ConditionTrue {
+			continue
+		}
+		if c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed {
+			if c.LastTransitionTime.Time.After(latest) {
+				latest = c.LastTransitionTime.Time
+			}
+		}
+	}
+	if latest.IsZero() {
+		return time.Now()
+	}
+	return latest
 }
 
 // countActiveJobs counts the number of non-completed, non-suspended Jobs in the given namespace.

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_drain_test.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_drain_test.go
@@ -1,0 +1,154 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	buildv1 "github.com/ls1intum/hades/HadesScheduler/HadesOperator/api/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func terminated(name string) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:  name,
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+	}
+}
+
+func running(name string) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:  name,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}
+}
+
+func status(name string, published bool) buildv1.ContainerStatus {
+	return buildv1.ContainerStatus{Name: name, LogsPublished: published}
+}
+
+// The drain gate must block deletion while any terminated container still has
+// unpublished logs, and must release once every terminated container is published.
+// Containers that never terminated (a step after a failing step, or the finalizer
+// on a failed job) must not block deletion.
+func TestAllTerminatedLogsPublished(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		statuses []buildv1.ContainerStatus
+		want     bool
+	}{
+		{
+			name: "succeeded job, all terminated logs published -> drained",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{terminated("step-1"), terminated("step-2")},
+				ContainerStatuses:     []corev1.ContainerStatus{terminated(FinalizerContainerName)},
+			}},
+			statuses: []buildv1.ContainerStatus{
+				status("step-1", true), status("step-2", true), status(FinalizerContainerName, true),
+			},
+			want: true,
+		},
+		{
+			name: "one terminated step still unpublished -> not drained",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{terminated("step-1"), terminated("step-2")},
+			}},
+			statuses: []buildv1.ContainerStatus{status("step-1", true), status("step-2", false)},
+			want:     false,
+		},
+		{
+			name: "failed job: later step never ran, published steps -> drained (unran does not block)",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				// step-1 terminated (failed), step-2 never ran, finalizer never ran.
+				InitContainerStatuses: []corev1.ContainerStatus{terminated("step-1")},
+			}},
+			statuses: []buildv1.ContainerStatus{
+				status("step-1", true), status("step-2", false), status(FinalizerContainerName, false),
+			},
+			want: true,
+		},
+		{
+			name: "running container does not block, terminated one published -> drained",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{terminated("step-1"), running("step-2")},
+			}},
+			statuses: []buildv1.ContainerStatus{status("step-1", true), status("step-2", false)},
+			want:     true,
+		},
+		{
+			name: "terminated finalizer unpublished -> not drained",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{terminated("step-1")},
+				ContainerStatuses:     []corev1.ContainerStatus{terminated(FinalizerContainerName)},
+			}},
+			statuses: []buildv1.ContainerStatus{status("step-1", true), status(FinalizerContainerName, false)},
+			want:     false,
+		},
+		{
+			name: "terminated container missing from status slice -> not drained",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{terminated("step-1")},
+			}},
+			statuses: []buildv1.ContainerStatus{},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allTerminatedLogsPublished(tt.pod, tt.statuses); got != tt.want {
+				t.Errorf("allTerminatedLogsPublished() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJobCompletionTime(t *testing.T) {
+	now := time.Now()
+	completion := metav1.NewTime(now.Add(-5 * time.Minute))
+	condTime := metav1.NewTime(now.Add(-3 * time.Minute))
+
+	t.Run("prefers Status.CompletionTime", func(t *testing.T) {
+		job := &batchv1.Job{Status: batchv1.JobStatus{
+			CompletionTime: &completion,
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue, LastTransitionTime: condTime},
+			},
+		}}
+		if got := jobCompletionTime(job); !got.Equal(completion.Time) {
+			t.Errorf("jobCompletionTime() = %v, want %v", got, completion.Time)
+		}
+	})
+
+	t.Run("falls back to true failed condition transition time", func(t *testing.T) {
+		job := &batchv1.Job{Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, LastTransitionTime: condTime},
+			},
+		}}
+		if got := jobCompletionTime(job); !got.Equal(condTime.Time) {
+			t.Errorf("jobCompletionTime() = %v, want %v", got, condTime.Time)
+		}
+	})
+
+	t.Run("ignores non-true conditions", func(t *testing.T) {
+		job := &batchv1.Job{Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionFalse, LastTransitionTime: condTime},
+			},
+		}}
+		if got := jobCompletionTime(job); got.Before(now) {
+			t.Errorf("jobCompletionTime() = %v, want ~now (>= %v)", got, now)
+		}
+	})
+
+	t.Run("no info falls back to ~now (not already timed out)", func(t *testing.T) {
+		job := &batchv1.Job{}
+		got := jobCompletionTime(job)
+		if time.Since(got) > logDrainTimeout {
+			t.Errorf("jobCompletionTime() = %v is already older than logDrainTimeout", got)
+		}
+	})
+}


### PR DESCRIPTION
## ✨ What is the change?

Adds a log-drain barrier in the HadesOperator so a completed `BuildJob` (and its pod) is only deleted after every terminated container's logs have been published.

## 📌 Reason for the change / Link to issue

The operator intermittently lost per-step build logs (reproduced ~40% loss in a 10-job burst; some jobs lost all logs). These logs were never captured, so it is not a LogManager/UI issue.

Root cause: in `internal/controller/buildjob_controller.go` `Reconcile`, when the Job is done and `DeleteOnComplete` is true, the operator read terminated containers' logs best-effort (errors logged then ignored) and then immediately deleted the `BuildJob` CR with foreground propagation, cascading to the pod. Kubernetes only serves container logs while the pod exists, and `TTLSecondsAfterFinished` is nil in this mode, so any terminated container whose logs had not yet been read lost them permanently. There was no barrier guaranteeing all logs were captured before deletion.

The barrier fix: when `DeleteOnComplete` is true, only complete-and-delete once every container that reached a terminal state in the pod has `LogsPublished=true`. Otherwise requeue after a short delay (1s) without deleting, so the next reconcile (which runs `updateContainerStatuses`) captures the remaining logs, then deletes.

Ordering: the drain gate runs BEFORE `setStatusCompleted`. `Reconcile` early-returns when the phase is `Succeeded`/`Failed`; setting the terminal phase and then requeuing to drain would trip that guard and never drain nor delete, leaking the CR and losing logs. Keeping the phase non-terminal while draining avoids that trap.

Edge cases handled:
- Failed jobs: a step fails and later init containers never run. The gate only inspects containers whose `State.Terminated` is set, so unran steps (and the finalizer, which never runs on a failed job) do not block deletion.
- Pod-gone safety valve: if the pod can no longer be resolved/fetched, logs are unrecoverable, so the operator deletes rather than requeuing forever (logged as a warning).
- Anti-infinite-requeue timeout: a bounded time (45s) since Job completion deletes anyway with a warning rather than requeuing forever.
- Transient (non-NotFound) pod-get errors return an error for controller backoff, unless past the timeout, in which case deletion proceeds.
- `DeleteOnComplete=false` is unchanged (that path keeps pods alive via TTL).

This change is independent of the `callback_url` per-job log destination work and does not change any CRD API types (no manifest regeneration needed). A companion PR flips the `DeleteOnComplete` chart default to `false` as an immediate mitigation.

## 🧪 Steps for Testing

1. From `HadesScheduler/HadesOperator`: `go build ./...`, `go vet ./...`, `go test ./...`.
2. New unit tests cover the gate: `TestAllTerminatedLogsPublished` (drained vs not, failed-job unran steps do not block, missing status entry blocks, running containers do not block) and `TestJobCompletionTime` (completion-time preference and fallbacks).
3. Workspace-wide `make lint` and `make test` from the repo root.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed builds now wait for logs from terminated containers to finish publishing before cleanup.
  * Build cleanup proceeds safely when pods are unavailable or after the log-drain timeout.
  * Improved handling of Kubernetes API errors during build cleanup.
  * Completion times are derived more reliably from available job status information.

* **Tests**
  * Added coverage for log publication checks, cleanup blocking, timeout behavior, and completion-time selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->