### PR TITLE
Fix build: import "time" in podlog_reader.go

### DIFF
--- a/HadesScheduler/k8s/podlog_reader.go
+++ b/HadesScheduler/k8s/podlog_reader.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/ls1intum/hades/hadesScheduler/log"
 	"github.com/ls1intum/hades/shared/buildlogs"


### PR DESCRIPTION
## ✨ What is the change?

Add the missing `"time"` import to `HadesScheduler/k8s/podlog_reader.go`.

## 📌 Reason for the change / Link to issue

#477 (`Stream build logs live for Docker and Kubernetes`) added `StreamContainerLogs(..., progress func(time.Time))` at `podlog_reader.go:99`, which references `time.Time`, but the file's import block was not updated. As a result **`main` does not compile**:

```
HadesScheduler/k8s/podlog_reader.go:99:134: undefined: time
```

This breaks `build`, `lint`, and the `HadesScheduler` / `HadesOperator` test jobs for every open PR (their merge-ref build inherits the broken `main`).

## 🧪 Steps for Testing

1. `cd HadesScheduler`
2. `go build ./...` - passes with this change, fails without it
3. `go vet ./k8s/...`

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed) - not needed; one-line missing-import fix restoring compilation
- [ ] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)