### PR TITLE
Add Kubernetes deployment workflows for prod and test

### DIFF
--- a/.github/workflows/deploy-k8s-prod.yml
+++ b/.github/workflows/deploy-k8s-prod.yml
@@ -1,0 +1,61 @@
+name: Deploy to Kubernetes (prod)
+
+# Manual production deploy. The version must be `latest` or a published GitHub Release
+# tag (validated before anything touches the cluster). To deploy a release, run this
+# workflow from that release's tag so the chart and CRDs match the released images.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Image tag to deploy: `latest` or a published release tag (e.g. 1.0.0)."
+        required: true
+        type: string
+        default: latest
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Validate version is a release or latest
+        run: |
+          set -euo pipefail
+          if [ "$VERSION" = "latest" ]; then
+            echo "Deploying 'latest'; skipping release validation."
+            exit 0
+          fi
+          # Require a published GitHub Release with this exact tag (no `v` prefix in this
+          # repo; the image tag equals the release tag).
+          if ! gh api "repos/${{ github.repository }}/releases/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error title=Invalid version::'$VERSION' is not a published GitHub release. Use 'latest' or an existing release tag."
+            exit 1
+          fi
+          echo "Release '$VERSION' exists."
+          # Best-effort guard: warn if no matching image was published to GHCR (a release
+          # existing does not prove the image build succeeded). The deploy still fails
+          # safely later (--atomic rolls back) if the image is truly missing.
+          if gh api --paginate "/orgs/hades-scheduler/packages/container/hades%2Fhades-api/versions" \
+               --jq '.[].metadata.container.tags[]' 2>/dev/null | grep -qx "$VERSION"; then
+            echo "Image tag '$VERSION' found on GHCR."
+          else
+            echo "::warning title=Image not confirmed::Could not confirm image tag '$VERSION' on ghcr.io/hades-scheduler/hades/hades-api. Continuing; the deploy will fail and roll back if the image is missing."
+          fi
+
+  deploy:
+    needs: validate
+    uses: ./.github/workflows/deploy-k8s.yml
+    secrets: inherit
+    with:
+      environment: k8s-prod
+      namespace: hades
+      values-file: values-prod.yaml
+      image-tag: ${{ inputs.version }}
+      # Deploy a release's chart from its tag so templates/CRDs match the images.
+      chart-ref: ${{ inputs.version != 'latest' && inputs.version || '' }}

--- a/.github/workflows/deploy-k8s-test.yml
+++ b/.github/workflows/deploy-k8s-test.yml
@@ -1,0 +1,26 @@
+name: Deploy to Kubernetes (test)
+
+# Manual test deploy. Any image tag is allowed: `latest`, a release tag, a branch/sha
+# tag, or `pr-N`. The chart and CRDs come from the ref this workflow is run from.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Image tag to deploy (e.g. latest, 1.0.0, pr-123, or a branch/sha tag)."
+        required: true
+        type: string
+        default: latest
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-k8s.yml
+    secrets: inherit
+    with:
+      environment: k8s-test
+      namespace: hades-test
+      values-file: values-test.yaml
+      image-tag: ${{ inputs.version }}

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -1,0 +1,150 @@
+name: Deploy to Kubernetes
+
+# Reusable workflow that installs/upgrades the Hades Helm chart into a Kubernetes
+# cluster. It is called by deploy-k8s-prod.yml and deploy-k8s-test.yml, which set the
+# target GitHub environment, namespace, values file and image tag. It never runs on its
+# own trigger.
+#
+# The GitHub environment supplies these secrets (add them once per environment):
+#   KUBE_CONFIG               - base64-encoded kubeconfig for the target cluster
+#   AUTH_KEY                  - protects the API /build endpoint
+#   DASHBOARD_USERNAME        - dashboard login user
+#   DASHBOARD_PASSWORD_HASH   - bcrypt hash of the dashboard password
+#   DASHBOARD_SESSION_SECRET  - dashboard session signing secret (>=32 chars)
+# The AUTH_KEY and dashboard values are materialised as in-cluster Secrets
+# (hades-auth, hades-dashboard) on every run; the first run creates them and later runs
+# keep them in sync.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: GitHub environment to deploy to (k8s-prod or k8s-test).
+        required: true
+        type: string
+      namespace:
+        description: Kubernetes namespace to deploy into.
+        required: true
+        type: string
+      values-file:
+        description: Environment values file under helm/hades/ (e.g. values-prod.yaml).
+        required: true
+        type: string
+      image-tag:
+        description: Container image tag to deploy for all four components.
+        required: true
+        type: string
+      chart-ref:
+        description: Git ref to source the chart and CRDs from. Empty = the triggering ref.
+        required: false
+        type: string
+        default: ""
+      release-name:
+        description: Helm release name.
+        required: false
+        type: string
+        default: hades
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Checkout chart source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.chart-ref }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.kube"
+          echo "$KUBE_CONFIG" | base64 --decode > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
+
+      - name: Ensure namespace exists
+        run: |
+          set -euo pipefail
+          kubectl create namespace "${{ inputs.namespace }}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create/update application Secrets
+        env:
+          NAMESPACE: ${{ inputs.namespace }}
+          AUTH_KEY: ${{ secrets.AUTH_KEY }}
+          DASHBOARD_USERNAME: ${{ secrets.DASHBOARD_USERNAME }}
+          DASHBOARD_PASSWORD_HASH: ${{ secrets.DASHBOARD_PASSWORD_HASH }}
+          DASHBOARD_SESSION_SECRET: ${{ secrets.DASHBOARD_SESSION_SECRET }}
+        run: |
+          set -euo pipefail
+          kubectl create secret generic hades-auth \
+            --namespace "$NAMESPACE" \
+            --from-literal=AUTH_KEY="$AUTH_KEY" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create secret generic hades-dashboard \
+            --namespace "$NAMESPACE" \
+            --from-literal=DASHBOARD_USERNAME="$DASHBOARD_USERNAME" \
+            --from-literal=DASHBOARD_PASSWORD_HASH="$DASHBOARD_PASSWORD_HASH" \
+            --from-literal=DASHBOARD_SESSION_SECRET="$DASHBOARD_SESSION_SECRET" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Apply CRDs
+        # Helm does not upgrade CRDs after the first install, so apply them explicitly.
+        # Server-side apply avoids the 264KB client-side last-applied-configuration
+        # annotation limit on the (large) BuildJob CRD.
+        run: kubectl apply --server-side --force-conflicts -f helm/hades/crds/
+
+      - name: Build chart dependencies
+        run: |
+          set -euo pipefail
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+          helm dependency build helm/hades
+
+      - name: Deploy with Helm
+        run: |
+          set -euo pipefail
+          helm upgrade --install "${{ inputs.release-name }}" helm/hades \
+            --namespace "${{ inputs.namespace }}" --create-namespace \
+            -f helm/hades/values.yaml \
+            -f "helm/hades/${{ inputs.values-file }}" \
+            --set-string hadesApi.image.tag="${{ inputs.image-tag }}" \
+            --set-string hadesScheduler.image.tag="${{ inputs.image-tag }}" \
+            --set-string hadesOperator.image.tag="${{ inputs.image-tag }}" \
+            --set-string hadesLogManager.image.tag="${{ inputs.image-tag }}" \
+            --atomic --timeout 10m
+
+      - name: Deployment summary
+        run: |
+          helm status "${{ inputs.release-name }}" --namespace "${{ inputs.namespace }}"
+          kubectl get pods --namespace "${{ inputs.namespace }}"
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          echo "::group::Pods"
+          kubectl get pods --namespace "${{ inputs.namespace }}" -o wide || true
+          echo "::endgroup::"
+          echo "::group::Events"
+          kubectl get events --namespace "${{ inputs.namespace }}" \
+            --sort-by=.lastTimestamp || true
+          echo "::endgroup::"
+          echo "::group::Not-ready pod details"
+          for pod in $(kubectl get pods --namespace "${{ inputs.namespace }}" \
+            --field-selector=status.phase!=Running -o name 2>/dev/null); do
+            kubectl describe "$pod" --namespace "${{ inputs.namespace }}" || true
+            kubectl logs "$pod" --namespace "${{ inputs.namespace }}" \
+              --all-containers --tail=100 || true
+          done
+          echo "::endgroup::"

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -6,7 +6,7 @@ name: Deploy to Kubernetes
 # own trigger.
 #
 # The GitHub environment supplies these secrets (add them once per environment):
-#   KUBE_CONFIG               - base64-encoded kubeconfig for the target cluster
+#   KUBE_CONFIG               - kubeconfig (plain YAML) for the target cluster
 #   AUTH_KEY                  - protects the API /build endpoint
 #   DASHBOARD_USERNAME        - dashboard login user
 #   DASHBOARD_PASSWORD_HASH   - bcrypt hash of the dashboard password
@@ -70,7 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.kube"
-          echo "$KUBE_CONFIG" | base64 --decode > "$HOME/.kube/config"
+          printf '%s\n' "$KUBE_CONFIG" > "$HOME/.kube/config"
           chmod 600 "$HOME/.kube/config"
           echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
 

--- a/Readme.md
+++ b/Readme.md
@@ -369,6 +369,41 @@ For production deployments in a VM:
 Hades includes Ansible playbooks for automated deployment.
 See the `ansible/hades/README.md` file for more details.
 
+### Kubernetes (GitHub Actions)
+
+Two manual workflows deploy the Helm chart to a Kubernetes cluster (one cluster,
+two namespaces):
+
+- **`Deploy to Kubernetes (prod)`** (`.github/workflows/deploy-k8s-prod.yml`) - deploys
+  into namespace `hades` from the `k8s-prod` environment. The `version` input must be
+  `latest` or a published GitHub Release tag; it is validated before anything touches the
+  cluster. To deploy a release, run the workflow **from that release's tag** so the chart
+  and CRDs match the released images.
+- **`Deploy to Kubernetes (test)`** (`.github/workflows/deploy-k8s-test.yml`) - deploys
+  into namespace `hades-test` from the `k8s-test` environment. The `version` input
+  accepts any image tag (`latest`, a release tag, `pr-N`, or a branch/sha tag). The chart
+  and CRDs come from the ref the workflow runs from.
+
+Both call the reusable `deploy-k8s.yml`, which writes the kubeconfig, creates the app
+Secrets, applies the CRDs (server-side, since Helm never upgrades CRDs), and runs
+`helm upgrade --install --atomic`. Per-environment, non-secret config lives in committed
+values files (`helm/hades/values-prod.yaml`, `helm/hades/values-test.yaml`).
+
+Each GitHub environment needs these secrets (add them once; the app Secrets are created
+on the first deploy and kept in sync afterwards):
+
+| Secret | Purpose |
+|---|---|
+| `KUBE_CONFIG` | base64-encoded kubeconfig for the target cluster |
+| `AUTH_KEY` | protects the API `/build` endpoint (Secret `hades-auth`) |
+| `DASHBOARD_USERNAME` | dashboard login user (Secret `hades-dashboard`) |
+| `DASHBOARD_PASSWORD_HASH` | bcrypt hash of the dashboard password |
+| `DASHBOARD_SESSION_SECRET` | dashboard session signing secret (>=32 chars) |
+
+`k8s-prod` uses a required-reviewer protection rule, so a production deploy waits for
+manual approval. TLS is handled in-cluster by cert-manager (the `letsencrypt-prod`
+cluster-issuer), so no ACME secrets are needed in the workflow.
+
 ### Releasing the Helm Chart
 
 The chart is published to GHCR as an OCI artifact by

--- a/Readme.md
+++ b/Readme.md
@@ -394,7 +394,7 @@ on the first deploy and kept in sync afterwards):
 
 | Secret | Purpose |
 |---|---|
-| `KUBE_CONFIG` | base64-encoded kubeconfig for the target cluster |
+| `KUBE_CONFIG` | kubeconfig (plain YAML) for the target cluster |
 | `AUTH_KEY` | protects the API `/build` endpoint (Secret `hades-auth`) |
 | `DASHBOARD_USERNAME` | dashboard login user (Secret `hades-dashboard`) |
 | `DASHBOARD_PASSWORD_HASH` | bcrypt hash of the dashboard password |

--- a/helm/hades/values-prod.yaml
+++ b/helm/hades/values-prod.yaml
@@ -1,0 +1,14 @@
+# Production overrides, layered on top of values.yaml by the
+# "Deploy to Kubernetes (prod)" workflow (namespace: hades).
+# Only non-secret configuration lives here; credentials are injected as
+# Kubernetes Secrets (hades-auth, hades-dashboard) created by the deploy workflow.
+
+hadesApi:
+  # Protect the /build endpoint with the AUTH_KEY from the hades-auth Secret.
+  authKeySecret: hades-auth
+  dashboard:
+    # Enable the dashboard, backed by the hades-dashboard Secret.
+    secretName: hades-dashboard
+
+ingress:
+  host: hades.student.k8s.aet.cit.tum.de

--- a/helm/hades/values-test.yaml
+++ b/helm/hades/values-test.yaml
@@ -1,0 +1,19 @@
+# Test overrides, layered on top of values.yaml by the
+# "Deploy to Kubernetes (test)" workflow (namespace: hades-test).
+# Only non-secret configuration lives here; credentials are injected as
+# Kubernetes Secrets (hades-auth, hades-dashboard) created by the deploy workflow.
+
+hadesApi:
+  # Protect the /build endpoint with the AUTH_KEY from the hades-auth Secret.
+  authKeySecret: hades-auth
+  dashboard:
+    # Enable the dashboard, backed by the hades-dashboard Secret.
+    secretName: hades-dashboard
+
+ingress:
+  host: hades-test.student.k8s.aet.cit.tum.de
+
+nats:
+  # values.yaml hardcodes the "hades" namespace in the NATS service FQDN, so the
+  # test namespace must point at its own NATS release (hades-nats.<namespace>).
+  host: hades-nats.hades-test.svc.cluster.local

--- a/website/docs/deployment/kubernetes-github-actions.md
+++ b/website/docs/deployment/kubernetes-github-actions.md
@@ -1,0 +1,84 @@
+---
+title: Kubernetes (GitHub Actions)
+sidebar_position: 4
+---
+
+# Deploying to Kubernetes with GitHub Actions
+
+Hades ships two manual GitHub Actions workflows that install/upgrade the Helm chart on a
+Kubernetes cluster. The default setup targets **one cluster with two namespaces**:
+`hades` (production) and `hades-test` (test).
+
+| Workflow | Environment | Namespace | Version rule |
+|---|---|---|---|
+| **Deploy to Kubernetes (prod)** | `k8s-prod` | `hades` | `latest` or a **published GitHub Release** tag (validated) |
+| **Deploy to Kubernetes (test)** | `k8s-test` | `hades-test` | **any** image tag (`latest`, a release tag, `pr-N`, a branch/sha tag) |
+
+Both are `workflow_dispatch` only - nothing deploys automatically. They call the reusable
+`deploy-k8s.yml`, which does the actual work.
+
+## How a deploy runs
+
+1. **Checkout** the chart source. Prod checks out the **release tag** (when the version is
+   not `latest`) so the chart templates and CRDs match the released images; test uses the
+   ref the workflow was run from.
+2. **Configure kubeconfig** from the environment's `KUBE_CONFIG` secret.
+3. **Ensure the namespace** exists.
+4. **Create/update the app Secrets** (`hades-auth`, `hades-dashboard`) from the
+   environment secrets. The first deploy creates them; later deploys keep them in sync.
+5. **Apply the CRDs** with a server-side apply. Helm never upgrades CRDs after the first
+   install, and server-side apply avoids the client-side annotation size limit on the
+   `BuildJob` CRD.
+6. **`helm upgrade --install --atomic`** with the base `values.yaml` plus the
+   environment values file, pinning all four component image tags to the chosen version.
+   `--atomic` rolls the release back on failure.
+
+The `version` input maps directly to the container image tag (this repo tags images with
+the release tag verbatim, with no `v` prefix).
+
+## Selecting the version
+
+- **Test**: type any image tag. Handy tags: `latest` (current `main`), `pr-123` (a PR
+  build), or a release tag.
+- **Prod**: type `latest` or an existing release tag (for example `1.0.0`). A bogus value
+  fails the `validate` job before the cluster is touched. To deploy a specific release,
+  also set **"Use workflow from"** to that release's tag so the chart matches the images.
+
+## Per-environment configuration
+
+Non-secret differences live in committed values files, layered on top of `values.yaml`:
+
+- `helm/hades/values-prod.yaml` - prod ingress host and Secret wiring.
+- `helm/hades/values-test.yaml` - test ingress host, Secret wiring, and the
+  `nats.host` override for the `hades-test` namespace.
+
+Only credentials are stored as GitHub secrets.
+
+## Required secrets
+
+Add these to **each** GitHub environment (`k8s-prod` and `k8s-test`):
+
+| Secret | Purpose |
+|---|---|
+| `KUBE_CONFIG` | base64-encoded kubeconfig for the target cluster |
+| `AUTH_KEY` | protects the API `/build` endpoint (Secret `hades-auth`) |
+| `DASHBOARD_USERNAME` | dashboard login user (Secret `hades-dashboard`) |
+| `DASHBOARD_PASSWORD_HASH` | bcrypt hash of the dashboard password |
+| `DASHBOARD_SESSION_SECRET` | dashboard session signing secret (>=32 chars) |
+
+Encode the kubeconfig with `base64 -w0 < kubeconfig` (or `base64 < kubeconfig | tr -d '\n'`
+on macOS) and paste the result as `KUBE_CONFIG`.
+
+## Production approval
+
+The `k8s-prod` environment uses a **required-reviewer** protection rule, so a production
+deploy pauses for manual approval before it runs. TLS certificates are issued in-cluster
+by cert-manager (the `letsencrypt-prod` cluster-issuer), so no ACME secrets are needed in
+the workflow.
+
+## Troubleshooting
+
+When a deploy fails, the reusable workflow prints pods, events, and the logs/description
+of any not-ready pod. Because `--atomic` rolls back (and deletes the release on a failed
+first install), check that diagnostics step in the run log for the real cause (commonly
+`ImagePullBackOff` for a nonexistent tag, or a missing secret).

--- a/website/docs/deployment/kubernetes-github-actions.md
+++ b/website/docs/deployment/kubernetes-github-actions.md
@@ -60,14 +60,13 @@ Add these to **each** GitHub environment (`k8s-prod` and `k8s-test`):
 
 | Secret | Purpose |
 |---|---|
-| `KUBE_CONFIG` | base64-encoded kubeconfig for the target cluster |
+| `KUBE_CONFIG` | kubeconfig (plain YAML) for the target cluster |
 | `AUTH_KEY` | protects the API `/build` endpoint (Secret `hades-auth`) |
 | `DASHBOARD_USERNAME` | dashboard login user (Secret `hades-dashboard`) |
 | `DASHBOARD_PASSWORD_HASH` | bcrypt hash of the dashboard password |
 | `DASHBOARD_SESSION_SECRET` | dashboard session signing secret (>=32 chars) |
 
-Encode the kubeconfig with `base64 -w0 < kubeconfig` (or `base64 < kubeconfig | tr -d '\n'`
-on macOS) and paste the result as `KUBE_CONFIG`.
+Paste the kubeconfig file's contents directly as `KUBE_CONFIG` (plain YAML, no encoding).
 
 ## Production approval
 


### PR DESCRIPTION
## ✨ What is the change?

Adds GitHub Actions deployment of the Hades Helm chart to two Kubernetes environments (one cluster, two namespaces: `hades` and `hades-test`). Previously nothing deployed the chart to a cluster - CI only SSHes a Docker Compose stack onto a VM, and Helm installs were manual.

- **`deploy-k8s.yml`** - reusable (`workflow_call`) workflow: checkout at a chosen ref → write kubeconfig from `KUBE_CONFIG` → ensure namespace → idempotent `hades-auth`/`hades-dashboard` Secret creation → **server-side** CRD apply (Helm never upgrades CRDs) → `helm dependency build` → `helm upgrade --install --atomic` with all four image tags pinned → summary + `if: failure()` diagnostics.
- **`deploy-k8s-prod.yml`** - manual dispatch into namespace `hades` via the `k8s-prod` environment. `version` must be `latest` or a published GitHub Release tag (validated before anything touches the cluster); the chart is sourced from the release tag so templates/CRDs match the released images.
- **`deploy-k8s-test.yml`** - manual dispatch into namespace `hades-test` via `k8s-test`. `version` accepts any image tag (`latest`, a release tag, `pr-N`, a branch/sha tag).
- **`helm/hades/values-prod.yaml` / `values-test.yaml`** - per-environment ingress host, Secret wiring, and the test-namespace `nats.host` override. Only credentials live in GitHub secrets.
- Docs: new "Kubernetes (GitHub Actions)" section in `Readme.md` and `website/docs/deployment/kubernetes-github-actions.md`.

The `k8s-prod` and `k8s-test` GitHub environments have been created; `k8s-prod` has a required-reviewer protection rule.

## 📌 Reason for the change / Link to issue

Automates chart deployment to Kubernetes with a protected, release-gated production path and a flexible test path, so releases no longer require a manual `helm upgrade`.

## 🧪 Steps for Testing

Each environment needs these secrets (the in-cluster app Secrets are created on the first deploy): `KUBE_CONFIG` (base64 kubeconfig), `AUTH_KEY`, `DASHBOARD_USERNAME`, `DASHBOARD_PASSWORD_HASH`, `DASHBOARD_SESSION_SECRET`.

1. Add the secrets to the `k8s-test` environment.
2. Run **Deploy to Kubernetes (test)** with `version=latest`; confirm the namespace, Secrets, and CRDs are created and all pods reach Ready, then hit the ingress host.
3. Run **Deploy to Kubernetes (prod)** with a bogus version; confirm the `validate` job fails before any cluster change. Then run it from a release tag with that version.

Local validation already run: `helm lint`, `helm template` for both env value files, and `actionlint` on all three workflows - all clean.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual Kubernetes deployment workflows for test and production environments.
  * Supports selecting and validating release versions with environment-specific deployment settings.
  * Automates namespace, secret, certificate, and application component setup.

* **Documentation**
  * Added deployment instructions covering configuration, approvals, required secrets, TLS, and troubleshooting.

* **Configuration**
  * Added production and test settings for authentication, dashboard access, ingress hosts, and service routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->