### PR TITLE
Point build samples at the released git-container image

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -123,7 +123,7 @@ jobs:
                   {
                     id: 2,
                     name: "Clone",
-                    image: "ghcr.io/hades-scheduler/hades/hades-clone-container:latest",
+                    image: "ghcr.io/hades-scheduler/git-container:1.0.0",
                     metadata: {
                       REPOSITORY_DIR: "/shared",
                       HADES_TEST_USERNAME: $gh_user,

--- a/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob.yaml
+++ b/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob.yaml
@@ -12,7 +12,7 @@ spec:
   steps:
     - id: 1
       name: "Clone"
-      image: "ghcr.io/hades-scheduler/hades/hades-clone-container:latest"
+      image: "ghcr.io/hades-scheduler/git-container:1.0.0"
       metadata:
         REPOSITORY_DIR: "/shared"
         HADES_TEST_USERNAME: ""

--- a/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_fail.yaml
+++ b/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_fail.yaml
@@ -12,7 +12,7 @@ spec:
   steps:
     - id: 1
       name: "Clone"
-      image: "ghcr.io/hades-scheduler/hades/hades-clone-container:latest"
+      image: "ghcr.io/hades-scheduler/git-container:1.0.0"
       metadata:
         REPOSITORY_DIR: "/shared"
         HADES_TEST_USERNAME: ""

--- a/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_report.yaml
+++ b/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_report.yaml
@@ -17,7 +17,7 @@ spec:
         ENDPOINT: "https://ma-yu.aet.cit.tum.de/v1/start_time"
     - id: 2
       name: "Clone"
-      image: "ghcr.io/hades-scheduler/hades/hades-clone-container:latest"
+      image: "ghcr.io/hades-scheduler/git-container:1.0.0"
       metadata:
         REPOSITORY_DIR: "/shared"
         HADES_TEST_USERNAME: ""

--- a/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_wait.yaml
+++ b/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_wait.yaml
@@ -12,7 +12,7 @@ spec:
   steps:
     - id: 1
       name: "Clone"
-      image: "ghcr.io/hades-scheduler/hades/hades-clone-container:latest"
+      image: "ghcr.io/hades-scheduler/git-container:1.0.0"
       metadata:
         REPOSITORY_DIR: "/shared"
         HADES_TEST_USERNAME: ""

--- a/bruno/api/Create Build Job (Test Fail) with Result Parse Step.bru
+++ b/bruno/api/Create Build Job (Test Fail) with Result Parse Step.bru
@@ -33,7 +33,7 @@ body:json {
       {
         "id": 1, // mandatory to declare the order of execution
         "name": "Clone",
-        "image": "ghcr.io/hades-scheduler/hades/hades-clone-container:latest", // mandatory
+        "image": "ghcr.io/hades-scheduler/git-container:1.0.0", // mandatory
         "volumeMounts": [
           { "name": "shared", "mountPath": "/shared" }
         ],

--- a/bruno/api/Create Build Job (Test Fail).bru
+++ b/bruno/api/Create Build Job (Test Fail).bru
@@ -34,7 +34,7 @@ body:json {
       {
         "id": 1, // mandatory to declare the order of execution
         "name": "Clone",
-        "image": "ghcr.io/hades-scheduler/hades/hades-clone-container:latest", // mandatory
+        "image": "ghcr.io/hades-scheduler/git-container:1.0.0", // mandatory
         "volumeMounts": [
           { "name": "shared", "mountPath": "/shared" }
         ],

--- a/bruno/api/Create Build Job (Test Succeed - Result Container).bru
+++ b/bruno/api/Create Build Job (Test Succeed - Result Container).bru
@@ -33,7 +33,7 @@ body:json {
       {
         "id": 1, // mandatory to declare the order of execution
         "name": "Clone",
-        "image": "ghcr.io/hades-scheduler/hades/hades-clone-container:latest", // mandatory
+        "image": "ghcr.io/hades-scheduler/git-container:1.0.0", // mandatory
         "volumeMounts": [
           { "name": "shared", "mountPath": "/shared" }
         ],

--- a/bruno/api/Create Build Job (Test Succeed) with Result Parse Step.bru
+++ b/bruno/api/Create Build Job (Test Succeed) with Result Parse Step.bru
@@ -33,7 +33,7 @@ body:json {
       {
         "id": 1, // mandatory to declare the order of execution
         "name": "Clone",
-        "image": "ghcr.io/hades-scheduler/hades/hades-clone-container:latest", // mandatory
+        "image": "ghcr.io/hades-scheduler/git-container:1.0.0", // mandatory
         "volumeMounts": [
           {
             "name": "shared",

--- a/bruno/api/Create Build Job (Test Succeed).bru
+++ b/bruno/api/Create Build Job (Test Succeed).bru
@@ -34,7 +34,7 @@ body:json {
       {
         "id": 1, // mandatory to declare the order of execution
         "name": "Clone",
-        "image": "ghcr.io/hades-scheduler/hades/hades-clone-container:latest", // mandatory
+        "image": "ghcr.io/hades-scheduler/git-container:1.0.0", // mandatory
         "volumeMounts": [
           { "name": "shared", "mountPath": "/shared" }
         ],

--- a/bruno/api/Create Build Job (long-running-debug).bru
+++ b/bruno/api/Create Build Job (long-running-debug).bru
@@ -33,7 +33,7 @@ body:json {
       {
         "id": 1, // mandatory to declare the order of execution
         "name": "Clone",
-        "image": "ghcr.io/hades-scheduler/hades/hades-clone-container:latest", // mandatory
+        "image": "ghcr.io/hades-scheduler/git-container:1.0.0", // mandatory
         "volumeMounts": [
           { "name": "shared", "mountPath": "/shared" }
         ],


### PR DESCRIPTION
## ✨ What is the change?

Replaces every reference to the never-published `ghcr.io/hades-scheduler/hades/hades-clone-container:latest` with the now-released **`ghcr.io/hades-scheduler/git-container:1.0.0`** (public, verified pullable).

Affected: the 6 Bruno build samples, the 4 operator `config/samples/*.yaml`, and `benchmark.yml`.

## 📌 Reason for the change / Link to issue

The org migration (#487) rewrote the clone-container image path to the `hades-scheduler` org, but that image was never published there, so every build using these samples fails with `ImagePullBackOff`. The image has now been released as `git-container:1.0.0`.

## 🧪 Steps for Testing

1. Submit any of the "Create Build Job" Bruno samples against a running Hades.
2. Confirm the clone step pulls `ghcr.io/hades-scheduler/git-container:1.0.0` and the build proceeds (no `ImagePullBackOff`).

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)