### PR TITLE
Surface stuck-pod failures (ImagePullBackOff) in the dashboard

### DIFF
--- a/HadesAPI/dashboard/dashboard.go
+++ b/HadesAPI/dashboard/dashboard.go
@@ -140,7 +140,10 @@ func (s *Server) Start(ctx context.Context) error {
 		if jobID == "" || !status.IsValid() {
 			return
 		}
-		summary := s.tracker.observe(jobID, status)
+		// An optional reason (e.g. why the job Failed) rides in a header; Get is
+		// nil-safe when no header was set.
+		reason := msg.Header.Get(buildstatus.ReasonHeader)
+		summary := s.tracker.observe(jobID, status, reason)
 		s.hub.broadcast(event{Type: eventJob, Job: summary})
 	})
 	if err != nil {

--- a/HadesAPI/dashboard/dashboard_test.go
+++ b/HadesAPI/dashboard/dashboard_test.go
@@ -170,7 +170,7 @@ func TestListJobsReflectsTracker(t *testing.T) {
 	s := testServer(t, true)
 	r := newRouter(s)
 	s.tracker.enqueue("job-1", "build", 3, hades.HighPriority)
-	s.tracker.observe("job-1", buildstatus.StatusRunning)
+	s.tracker.observe("job-1", buildstatus.StatusRunning, "")
 
 	cookie := login(t, r)
 	w := httptest.NewRecorder()
@@ -348,9 +348,26 @@ func TestJobLogsRejectsNonUUID(t *testing.T) {
 	}
 }
 
+func TestTrackerObserveReason(t *testing.T) {
+	tr := newTracker(time.Hour)
+	// A reason attached to a Failed transition is surfaced on the summary.
+	sum := tr.observe("j", buildstatus.StatusFailed, "ImagePullBackOff: back-off")
+	if sum.Status != "Failed" {
+		t.Fatalf("status = %q, want Failed", sum.Status)
+	}
+	if sum.Reason != "ImagePullBackOff: back-off" {
+		t.Fatalf("reason = %q, want the ImagePullBackOff message", sum.Reason)
+	}
+	// A later empty-reason update must not wipe the stored reason.
+	sum = tr.observe("j", buildstatus.StatusFailed, "")
+	if sum.Reason != "ImagePullBackOff: back-off" {
+		t.Fatalf("reason was cleared by an empty update: %q", sum.Reason)
+	}
+}
+
 func TestTrackerSweep(t *testing.T) {
 	tr := newTracker(time.Millisecond)
-	tr.observe("j", buildstatus.StatusSucceeded)
+	tr.observe("j", buildstatus.StatusSucceeded, "")
 	// Force updatedAt into the past.
 	tr.mu.Lock()
 	tr.jobs["j"].updatedAt = time.Now().Add(-time.Hour)

--- a/HadesAPI/dashboard/tracker.go
+++ b/HadesAPI/dashboard/tracker.go
@@ -30,6 +30,7 @@ type JobSummary struct {
 	Name       string     `json:"name,omitempty"`
 	Priority   string     `json:"priority,omitempty"`
 	Status     string     `json:"status"`
+	Reason     string     `json:"reason,omitempty"`
 	StepCount  int        `json:"stepCount,omitempty"`
 	QueuedAt   *time.Time `json:"queuedAt,omitempty"`
 	StartedAt  *time.Time `json:"startedAt,omitempty"`
@@ -44,6 +45,7 @@ type jobRecord struct {
 	priority   hades.Priority
 	stepCount  int
 	status     buildstatus.JobStatus
+	reason     string
 	queuedAt   time.Time
 	startedAt  time.Time
 	finishedAt time.Time
@@ -57,6 +59,7 @@ func (r *jobRecord) dto() JobSummary {
 		Priority:  string(r.priority),
 		StepCount: r.stepCount,
 		Status:    r.status.String(),
+		Reason:    r.reason,
 	}
 	if !r.queuedAt.IsZero() {
 		t := r.queuedAt
@@ -130,8 +133,10 @@ func (t *tracker) enqueue(jobID, name string, stepCount int, priority hades.Prio
 	return rec.dto()
 }
 
-// observe applies a status transition learned from the live subscription.
-func (t *tracker) observe(jobID string, status buildstatus.JobStatus) JobSummary {
+// observe applies a status transition learned from the live subscription. An
+// optional reason (e.g. "ImagePullBackOff: ...") explaining the status is stored
+// when present and retained across later empty-reason updates.
+func (t *tracker) observe(jobID string, status buildstatus.JobStatus, reason string) JobSummary {
 	now := time.Now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -142,6 +147,9 @@ func (t *tracker) observe(jobID string, status buildstatus.JobStatus) JobSummary
 		t.enforceInsertCapLocked()
 	}
 	rec.status = status
+	if reason != "" {
+		rec.reason = reason
+	}
 	rec.updatedAt = now
 	switch status {
 	case buildstatus.StatusQueued:

--- a/HadesAPI/web/src/components/jobs-table.tsx
+++ b/HadesAPI/web/src/components/jobs-table.tsx
@@ -83,6 +83,14 @@ export function JobsTable({
               </TableCell>
               <TableCell>
                 <StatusBadge status={job.status} />
+                {job.reason && (
+                  <div
+                    className="mt-1 max-w-[22rem] truncate text-xs text-muted-foreground"
+                    title={job.reason}
+                  >
+                    {job.reason}
+                  </div>
+                )}
               </TableCell>
               <TableCell className="hidden sm:table-cell">
                 {job.priority ? (

--- a/HadesAPI/web/src/lib/types.ts
+++ b/HadesAPI/web/src/lib/types.ts
@@ -13,6 +13,8 @@ export interface JobSummary {
   name?: string;
   priority?: string;
   status: JobStatus;
+  /** Optional explanation of the status, e.g. why the job Failed. */
+  reason?: string;
   stepCount?: number;
   queuedAt?: string;
   startedAt?: string;

--- a/HadesAPI/web/src/pages/job-detail.tsx
+++ b/HadesAPI/web/src/pages/job-detail.tsx
@@ -64,6 +64,12 @@ export function JobDetailPage() {
             </div>
           </div>
 
+          {job.data.reason && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {job.data.reason}
+            </div>
+          )}
+
           <div className="grid gap-3 text-sm sm:grid-cols-3">
             <TimeField label="Queued" value={formatTime(job.data.queuedAt)} />
             <TimeField label="Started" value={formatTime(job.data.startedAt)} />

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_containers.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_containers.go
@@ -226,11 +226,10 @@ func podStuckReason(pod *corev1.Pod) (string, bool) {
 			if w == nil || !terminalWaitingReasons[w.Reason] {
 				continue
 			}
-			detail := w.Reason
-			if w.Message != "" {
-				detail = fmt.Sprintf("%s: %s", w.Reason, w.Message)
-			}
-			return fmt.Sprintf("%s (%s %d, %s)", detail, label, i+1, cs.Name), true
+			// Keep it concise: the reason plus the offending image and step, not the
+			// kubelet's verbose multi-line Waiting.Message (which repeats the pull
+			// error in full).
+			return fmt.Sprintf("%s (%s %d): %s", w.Reason, label, i+1, cs.Image), true
 		}
 		return "", false
 	}

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_containers.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_containers.go
@@ -132,7 +132,7 @@ func (r *BuildJobReconciler) logsDrained(ctx context.Context, bj *buildv1.BuildJ
 // least one container has terminated but its live log stream has not finished
 // publishing, signalling the caller to requeue so the job is not finalized (and
 // its pod deleted) before the tail logs are captured.
-func (r *BuildJobReconciler) updateContainerStatuses(ctx context.Context, bj *buildv1.BuildJob) (draining bool, err error) {
+func (r *BuildJobReconciler) updateContainerStatuses(ctx context.Context, bj *buildv1.BuildJob) (draining bool, pod *corev1.Pod, err error) {
 	slog.Info("Updating container statuses for BuildJob", "buildJob", bj.Name)
 
 	pl := r.podLogReader(bj.Namespace, bj.Name)
@@ -140,12 +140,12 @@ func (r *BuildJobReconciler) updateContainerStatuses(ctx context.Context, bj *bu
 	podName, err := pl.ResolvePodName(ctx)
 	if err != nil {
 		slog.Error("Failed to resolve pod name", "error", err)
-		return false, err
+		return false, nil, err
 	}
 
 	p, err := r.K8sClient.CoreV1().Pods(bj.Namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -196,7 +196,48 @@ func (r *BuildJobReconciler) updateContainerStatuses(ctx context.Context, bj *bu
 		fresh.Status.PodName = p.Name
 		return r.Status().Update(ctx, &fresh)
 	})
-	return draining, err
+	return draining, p, err
+}
+
+// terminalWaitingReasons are container Waiting.Reason values that do not clear on
+// their own, so a pod sitting in one is stuck and its BuildJob should fail.
+// Transient reasons (ErrImagePull, ContainerCreating, PodInitializing) are
+// intentionally excluded: the backoff/permanent states below only surface after
+// the kubelet has already retried, so they act as an implicit grace period and a
+// merely slow or first-attempt pull is not mistaken for a failure.
+var terminalWaitingReasons = map[string]bool{
+	"ImagePullBackOff":           true,
+	"ErrImageNeverPull":          true,
+	"InvalidImageName":           true,
+	"CreateContainerConfigError": true,
+	"CreateContainerError":       true,
+	"CrashLoopBackOff":           true,
+}
+
+// podStuckReason reports whether pod has a container wedged in a terminal waiting
+// state (e.g. ImagePullBackOff) and, if so, a concise human-readable reason. Init
+// containers (the build steps) are checked first, so a stuck step is reported
+// before the app/finalizer container, which sits in PodInitializing until the
+// steps finish.
+func podStuckReason(pod *corev1.Pod) (string, bool) {
+	check := func(statuses []corev1.ContainerStatus, label string) (string, bool) {
+		for i, cs := range statuses {
+			w := cs.State.Waiting
+			if w == nil || !terminalWaitingReasons[w.Reason] {
+				continue
+			}
+			detail := w.Reason
+			if w.Message != "" {
+				detail = fmt.Sprintf("%s: %s", w.Reason, w.Message)
+			}
+			return fmt.Sprintf("%s (%s %d, %s)", detail, label, i+1, cs.Name), true
+		}
+		return "", false
+	}
+	if reason, ok := check(pod.Status.InitContainerStatuses, "step"); ok {
+		return reason, true
+	}
+	return check(pod.Status.ContainerStatuses, "container")
 }
 
 // updateContainerStateMap updates the ContainerStatus for a specific container

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
@@ -148,13 +148,48 @@ func (r *BuildJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err == nil {
 		// Job already exists check the status of the containers. draining is true
 		// while a terminated container's live log stream is still publishing.
-		draining, err := r.updateContainerStatuses(ctx, &bj)
+		draining, pod, err := r.updateContainerStatuses(ctx, &bj)
 		if err != nil {
 			// draining is unreliable when the status update failed, so requeue
 			// instead of proceeding: finalizing here could delete the pod while a
 			// container's log stream is still draining and lose its tail logs.
 			slog.Error("Failed to update container statuses", "error", err)
 			return ctrl.Result{}, fmt.Errorf("updating container statuses: %w", err)
+		}
+
+		// A pod wedged in a terminal waiting state (e.g. ImagePullBackOff) never
+		// runs, so its Job never gets a Complete/Failed condition and jobFinished
+		// would keep the BuildJob "Running" forever. Fail it with the reason and
+		// delete the Job (removing the runaway pod and stopping the endless pull
+		// retries, which TTLSecondsAfterFinished would never reap on an unfinished
+		// Job). No log-drain gate: the containers never started, so there are no
+		// logs to wait for.
+		if reason, stuck := podStuckReason(pod); stuck {
+			slog.Warn("BuildJob pod is stuck; failing", "buildJob", bj.Name, "reason", reason)
+			if err := r.setStatusCompleted(ctx, req.NamespacedName, bj.Name, false, reason); err != nil {
+				if apierrors.IsConflict(err) {
+					return ctrl.Result{RequeueAfter: conflictRequeueDelay}, nil
+				}
+				return ctrl.Result{}, err
+			}
+			r.logStreams().stopJob(bj.Namespace, bj.Name)
+
+			policy := metav1.DeletePropagationForeground
+			if err := r.Delete(ctx, &existingJob, &client.DeleteOptions{PropagationPolicy: &policy}); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+			// Remove the CR too only when configured to clean up on completion;
+			// otherwise keep it as the failure record (phase Failed, reason in
+			// Status.Message).
+			if r.DeleteOnComplete {
+				if err := r.Delete(ctx, &bj, &client.DeleteOptions{PropagationPolicy: &policy}); err != nil && !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
+			}
+			if err := r.admitOneSuspendedJob(ctx, bj.Namespace); err != nil {
+				slog.Error("Failed to admit suspended job after stuck-pod failure", "error", err)
+			}
+			return ctrl.Result{}, nil
 		}
 
 		// Job already exists, check the status of the job
@@ -384,7 +419,7 @@ func (r *BuildJobReconciler) setStatusCompleted(ctx context.Context, nn types.Na
 		slog.Info("Published job succeeded status", "job_id", jobID)
 		return nil
 	} else {
-		if err := r.Publisher.PublishJobStatus(ctx, buildstatus.StatusFailed, jobID); err != nil {
+		if err := r.Publisher.PublishJobStatus(ctx, buildstatus.StatusFailed, jobID, msg); err != nil {
 			slog.Error("Failed to publish job failed status", "job_id", jobID, "error", err)
 			return err
 		}

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_stuck_test.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_stuck_test.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func waitingStatus(name, reason, message string) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name: name,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: reason, Message: message},
+		},
+	}
+}
+
+func runningStatus(name string) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:  name,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}
+}
+
+func TestPodStuckReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		pod        corev1.Pod
+		wantStuck  bool
+		wantSubstr string
+	}{
+		{
+			name: "init container ImagePullBackOff is stuck",
+			pod: corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					waitingStatus("step-1", "ImagePullBackOff", `Back-off pulling image "ghcr.io/x/y:1.0.0"`),
+				},
+			}},
+			wantStuck:  true,
+			wantSubstr: "ImagePullBackOff",
+		},
+		{
+			name: "app container CrashLoopBackOff is stuck",
+			pod: corev1.Pod{Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					waitingStatus("finalizer", "CrashLoopBackOff", "back-off restarting failed container"),
+				},
+			}},
+			wantStuck:  true,
+			wantSubstr: "CrashLoopBackOff",
+		},
+		{
+			name: "transient ErrImagePull is not stuck",
+			pod: corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					waitingStatus("step-1", "ErrImagePull", "pulling"),
+				},
+			}},
+			wantStuck: false,
+		},
+		{
+			name: "transient ContainerCreating is not stuck",
+			pod: corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					waitingStatus("step-1", "ContainerCreating", ""),
+				},
+			}},
+			wantStuck: false,
+		},
+		{
+			name: "running container is not stuck",
+			pod: corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{runningStatus("step-1")},
+			}},
+			wantStuck: false,
+		},
+		{
+			name: "init container reason wins over app container PodInitializing",
+			pod: corev1.Pod{Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					waitingStatus("step-2", "ImagePullBackOff", "back-off"),
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					waitingStatus("finalizer", "PodInitializing", ""),
+				},
+			}},
+			wantStuck:  true,
+			wantSubstr: "step 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, stuck := podStuckReason(&tt.pod)
+			if stuck != tt.wantStuck {
+				t.Fatalf("stuck = %v, want %v (reason=%q)", stuck, tt.wantStuck, reason)
+			}
+			if tt.wantStuck && !strings.Contains(reason, tt.wantSubstr) {
+				t.Fatalf("reason %q does not contain %q", reason, tt.wantSubstr)
+			}
+			if !tt.wantStuck && reason != "" {
+				t.Fatalf("expected empty reason, got %q", reason)
+			}
+		})
+	}
+}

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_stuck_test.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_stuck_test.go
@@ -7,11 +7,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func waitingStatus(name, reason, message string) corev1.ContainerStatus {
+func waitingStatus(name, image, reason string) corev1.ContainerStatus {
 	return corev1.ContainerStatus{
-		Name: name,
+		Name:  name,
+		Image: image,
 		State: corev1.ContainerState{
-			Waiting: &corev1.ContainerStateWaiting{Reason: reason, Message: message},
+			Waiting: &corev1.ContainerStateWaiting{Reason: reason},
 		},
 	}
 }
@@ -25,36 +26,36 @@ func runningStatus(name string) corev1.ContainerStatus {
 
 func TestPodStuckReason(t *testing.T) {
 	tests := []struct {
-		name       string
-		pod        corev1.Pod
-		wantStuck  bool
-		wantSubstr string
+		name        string
+		pod         corev1.Pod
+		wantStuck   bool
+		wantSubstrs []string
 	}{
 		{
 			name: "init container ImagePullBackOff is stuck",
 			pod: corev1.Pod{Status: corev1.PodStatus{
 				InitContainerStatuses: []corev1.ContainerStatus{
-					waitingStatus("step-1", "ImagePullBackOff", `Back-off pulling image "ghcr.io/x/y:1.0.0"`),
+					waitingStatus("step-1", "ghcr.io/x/y:1.0.0", "ImagePullBackOff"),
 				},
 			}},
-			wantStuck:  true,
-			wantSubstr: "ImagePullBackOff",
+			wantStuck:   true,
+			wantSubstrs: []string{"ImagePullBackOff", "step 1", "ghcr.io/x/y:1.0.0"},
 		},
 		{
 			name: "app container CrashLoopBackOff is stuck",
 			pod: corev1.Pod{Status: corev1.PodStatus{
 				ContainerStatuses: []corev1.ContainerStatus{
-					waitingStatus("finalizer", "CrashLoopBackOff", "back-off restarting failed container"),
+					waitingStatus("finalizer", "busybox:latest", "CrashLoopBackOff"),
 				},
 			}},
-			wantStuck:  true,
-			wantSubstr: "CrashLoopBackOff",
+			wantStuck:   true,
+			wantSubstrs: []string{"CrashLoopBackOff", "busybox:latest"},
 		},
 		{
 			name: "transient ErrImagePull is not stuck",
 			pod: corev1.Pod{Status: corev1.PodStatus{
 				InitContainerStatuses: []corev1.ContainerStatus{
-					waitingStatus("step-1", "ErrImagePull", "pulling"),
+					waitingStatus("step-1", "ghcr.io/x/y:1.0.0", "ErrImagePull"),
 				},
 			}},
 			wantStuck: false,
@@ -63,7 +64,7 @@ func TestPodStuckReason(t *testing.T) {
 			name: "transient ContainerCreating is not stuck",
 			pod: corev1.Pod{Status: corev1.PodStatus{
 				InitContainerStatuses: []corev1.ContainerStatus{
-					waitingStatus("step-1", "ContainerCreating", ""),
+					waitingStatus("step-1", "ghcr.io/x/y:1.0.0", "ContainerCreating"),
 				},
 			}},
 			wantStuck: false,
@@ -79,14 +80,14 @@ func TestPodStuckReason(t *testing.T) {
 			name: "init container reason wins over app container PodInitializing",
 			pod: corev1.Pod{Status: corev1.PodStatus{
 				InitContainerStatuses: []corev1.ContainerStatus{
-					waitingStatus("step-2", "ImagePullBackOff", "back-off"),
+					waitingStatus("step-2", "ghcr.io/x/y:2.0.0", "ImagePullBackOff"),
 				},
 				ContainerStatuses: []corev1.ContainerStatus{
-					waitingStatus("finalizer", "PodInitializing", ""),
+					waitingStatus("finalizer", "hades-finalizer:latest", "PodInitializing"),
 				},
 			}},
-			wantStuck:  true,
-			wantSubstr: "step 1",
+			wantStuck:   true,
+			wantSubstrs: []string{"step 1", "ghcr.io/x/y:2.0.0"},
 		},
 	}
 
@@ -96,11 +97,16 @@ func TestPodStuckReason(t *testing.T) {
 			if stuck != tt.wantStuck {
 				t.Fatalf("stuck = %v, want %v (reason=%q)", stuck, tt.wantStuck, reason)
 			}
-			if tt.wantStuck && !strings.Contains(reason, tt.wantSubstr) {
-				t.Fatalf("reason %q does not contain %q", reason, tt.wantSubstr)
+			if !tt.wantStuck {
+				if reason != "" {
+					t.Fatalf("expected empty reason, got %q", reason)
+				}
+				return
 			}
-			if !tt.wantStuck && reason != "" {
-				t.Fatalf("expected empty reason, got %q", reason)
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(reason, sub) {
+					t.Fatalf("reason %q does not contain %q", reason, sub)
+				}
 			}
 		})
 	}

--- a/HadesScheduler/docker/scheduler.go
+++ b/HadesScheduler/docker/scheduler.go
@@ -16,9 +16,14 @@ import (
 	"github.com/hades-scheduler/hades/shared/buildlogs"
 	"github.com/hades-scheduler/hades/shared/buildstatus"
 	"github.com/hades-scheduler/hades/shared/payload"
+	"github.com/hades-scheduler/hades/shared/redact"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 )
+
+// maxStatusReasonLen caps the failure reason attached to a status event so a
+// verbose executor error stays within NATS header limits.
+const maxStatusReasonLen = 500
 
 // Options holds the per-scheduler Docker execution settings applied to every
 // step container (script shell, resource limits, autoremove, and the per-job
@@ -143,8 +148,15 @@ func (d *Scheduler) ScheduleJob(ctx context.Context, job payload.QueuePayload) e
 
 	err := dockerJob.execute(ctx)
 	if err != nil {
-		if err := d.statusPublisher.PublishJobStatus(ctx, buildstatus.StatusFailed, job.ID.String()); err != nil {
-			jobLogger.Warn("failed to publish failed status", "error", err)
+		// Surface why the job failed (e.g. an image pull error) to the dashboard.
+		// Redact secret-looking tokens and cap the length so a verbose daemon error
+		// stays within NATS header limits.
+		reason := redact.Default().Text(err.Error())
+		if runes := []rune(reason); len(runes) > maxStatusReasonLen {
+			reason = string(runes[:maxStatusReasonLen]) + "…"
+		}
+		if perr := d.statusPublisher.PublishJobStatus(ctx, buildstatus.StatusFailed, job.ID.String(), reason); perr != nil {
+			jobLogger.Warn("failed to publish failed status", "error", perr)
 		}
 		jobLogger.Error("Failed to execute job", "error", err)
 		return err

--- a/HadesScheduler/log/nats.go
+++ b/HadesScheduler/log/nats.go
@@ -40,7 +40,7 @@ func NewNATSPublisher(nc *nats.Conn) (*NATSPublisher, error) {
 
 // PublishJobStatus publishes a job status change to NATS.
 // The status is published to the subject "hades.status.{status}".
-func (np *NATSPublisher) PublishJobStatus(ctx context.Context, jobStatus status.JobStatus, jobID string) error {
+func (np *NATSPublisher) PublishJobStatus(ctx context.Context, jobStatus status.JobStatus, jobID string, reason ...string) error {
 	if jobID == "" {
 		return fmt.Errorf("empty job ID")
 	}
@@ -50,9 +50,14 @@ func (np *NATSPublisher) PublishJobStatus(ctx context.Context, jobStatus status.
 	}
 
 	subject := status.StatusSubject(jobStatus)
-	data := []byte(jobID)
+	// Payload stays the bare job ID; an optional reason rides in a header so
+	// payload-only subscribers (HadesLogManager) are unaffected.
+	msg := &nats.Msg{Subject: subject, Data: []byte(jobID)}
+	if r := status.FirstReason(reason...); r != "" {
+		msg.Header = nats.Header{status.ReasonHeader: []string{r}}
+	}
 
-	if err := np.nc.Publish(subject, data); err != nil {
+	if err := np.nc.PublishMsg(msg); err != nil {
 		return fmt.Errorf("publishing job status %s for job %s: %w", jobStatus, jobID, err)
 	}
 

--- a/HadesScheduler/log/publisher.go
+++ b/HadesScheduler/log/publisher.go
@@ -22,6 +22,6 @@ func (np *NoopPublisher) PublishJobLog(ctx context.Context, buildJobLog logs.Log
 }
 
 // PublishJobStatus does nothing and always returns nil
-func (np *NoopPublisher) PublishJobStatus(ctx context.Context, status status.JobStatus, jobID string) error {
+func (np *NoopPublisher) PublishJobStatus(ctx context.Context, status status.JobStatus, jobID string, reason ...string) error {
 	return nil
 }

--- a/bruno/api/Create Build Job (Image Pull Failure).bru
+++ b/bruno/api/Create Build Job (Image Pull Failure).bru
@@ -1,0 +1,55 @@
+meta {
+  name: Create Build Job (Image Pull Failure)
+  type: http
+  seq: 8
+}
+
+post {
+  url: http://{{hostname}}/build
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: hades
+  password: {{auth_key}}
+}
+
+body:json {
+  {
+    // Reproduces the ImagePullBackOff case: the step image does not exist, so the
+    // pod never runs. The operator detects the stuck pod, marks the job Failed with
+    // an "ImagePullBackOff: ..." reason, and deletes the underlying Job. Watch the
+    // job flip to Failed (with the reason) in the dashboard job detail page.
+    "name": "Image Pull Failure",
+    "metadata": {
+      "GLOBAL": "test"
+    },
+    "timestamp": "2021-01-01T00:00:00.000Z",
+    "priority": 3,
+    "steps": [
+      {
+        "id": 1,
+        "name": "Missing image",
+        "image": "ghcr.io/hades-scheduler/this-image-does-not-exist:latest",
+        "script": "echo this never runs"
+      }
+    ]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("build request is accepted", function () {
+    expect(res.getStatus()).to.equal(200);
+    expect(res.getBody().job_id).to.be.a("string");
+  });
+
+  // Store the id so the failure can be verified in the dashboard job detail page.
+  bru.setVar("stuck_job_id", res.getBody().job_id);
+  console.log("Submitted image-pull-failure job:", res.getBody().job_id);
+  console.log("It should flip to Failed with an ImagePullBackOff reason in the dashboard.");
+}

--- a/shared/buildstatus/jobstatus.go
+++ b/shared/buildstatus/jobstatus.go
@@ -15,10 +15,18 @@ import (
 // in sync.
 type JobStatus string
 
-// StatusPublisher publishes job status transitions to NATS JetStream.
+// StatusPublisher publishes job status transitions to NATS JetStream. An
+// optional reason may accompany a status (typically a terminal Failed) to
+// explain it, e.g. "ImagePullBackOff: ...". Only the first reason is used.
 type StatusPublisher interface {
-	PublishJobStatus(ctx context.Context, status JobStatus, jobID string) error
+	PublishJobStatus(ctx context.Context, status JobStatus, jobID string, reason ...string) error
 }
+
+// ReasonHeader is the NATS message header carrying an optional human-readable
+// reason for a status transition (e.g. why a job Failed). The message payload
+// stays the bare job ID for backward compatibility, so subscribers that only
+// read the payload (e.g. HadesLogManager) are unaffected.
+const ReasonHeader = "X-Hades-Reason"
 
 // The job lifecycle statuses. Queued and Running are transient; Succeeded,
 // Failed, and Stopped are terminal.
@@ -52,4 +60,16 @@ func (js JobStatus) IsValid() bool {
 // StatusSubject returns the NATS subject for publishing the given status.
 func StatusSubject(status JobStatus) string {
 	return fmt.Sprintf(StatusSubjectFormat, status)
+}
+
+// FirstReason returns the first non-empty reason from a variadic reason list,
+// or "" if none was provided. Publishers use it to normalize the optional
+// PublishJobStatus reason argument.
+func FirstReason(reason ...string) string {
+	for _, r := range reason {
+		if r != "" {
+			return r
+		}
+	}
+	return ""
 }

--- a/shared/buildstatus/jobstatus_test.go
+++ b/shared/buildstatus/jobstatus_test.go
@@ -70,3 +70,23 @@ func TestJobStatus_IsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestFirstReason(t *testing.T) {
+	tests := []struct {
+		name    string
+		reasons []string
+		want    string
+	}{
+		{"none", nil, ""},
+		{"single", []string{"ImagePullBackOff"}, "ImagePullBackOff"},
+		{"skips empty", []string{"", "boom"}, "boom"},
+		{"all empty", []string{"", ""}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FirstReason(tt.reasons...); got != tt.want {
+				t.Fatalf("FirstReason(%v) = %q, want %q", tt.reasons, got, tt.want)
+			}
+		})
+	}
+}

--- a/shared/nats/publisher.go
+++ b/shared/nats/publisher.go
@@ -106,7 +106,7 @@ func (hp *HadesNATSPublisher) EnqueueJobWithPriority(ctx context.Context, queueP
 // subject "hades.jobstatus.{status}". Subscribers such as HadesLogManager use
 // these events to track a job's lifecycle. Nothing publishes the Queued status
 // today except the API on enqueue, so this completes the lifecycle feed.
-func (hp *HadesNATSPublisher) PublishJobStatus(ctx context.Context, jobStatus buildstatus.JobStatus, jobID string) error {
+func (hp *HadesNATSPublisher) PublishJobStatus(ctx context.Context, jobStatus buildstatus.JobStatus, jobID string, reason ...string) error {
 	if jobID == "" {
 		return fmt.Errorf("empty job ID")
 	}
@@ -114,7 +114,13 @@ func (hp *HadesNATSPublisher) PublishJobStatus(ctx context.Context, jobStatus bu
 		return fmt.Errorf("invalid job status: %s", jobStatus)
 	}
 	subject := buildstatus.StatusSubject(jobStatus)
-	if err := hp.natsConnection.Publish(subject, []byte(jobID)); err != nil {
+	// Payload stays the bare job ID; an optional reason rides in a header so
+	// payload-only subscribers (HadesLogManager) are unaffected.
+	msg := &nats.Msg{Subject: subject, Data: []byte(jobID)}
+	if r := buildstatus.FirstReason(reason...); r != "" {
+		msg.Header = nats.Header{buildstatus.ReasonHeader: []string{r}}
+	}
+	if err := hp.natsConnection.PublishMsg(msg); err != nil {
 		return fmt.Errorf("publishing job status %s for job %s: %w", jobStatus, jobID, err)
 	}
 	slog.Debug("Published job status", "job_id", jobID, "status", jobStatus, "subject", subject)


### PR DESCRIPTION
## ✨ What is the change?

A BuildJob whose step image can't be pulled (`ImagePullBackOff`) previously sat **forever showing "Running"** in the operator dashboard. Three signals were dropped: the operator judged completion only from `batch/v1` Job conditions (a stuck pod never sets one), the container `Waiting.Reason` was collapsed to `Pending`, and the dashboard only knew a 5-value status enum.

This makes such failures visible and cleans them up:

- **Operator** (`buildjob_controller.go`, `buildjob_containers.go`): new `podStuckReason` detects a pod wedged in a terminal waiting state (`ImagePullBackOff`, `ErrImageNeverPull`, `InvalidImageName`, `CreateContainer*Error`, `CrashLoopBackOff`) - init containers first, transient reasons ignored so a slow/first-attempt pull isn't mistaken for failure. `Reconcile` fails the BuildJob with the reason (in `Status.Message`) and **deletes the underlying Job**, removing the runaway pod that `TTLSecondsAfterFinished` would never reap. This also self-heals already-stuck jobs on operator upgrade.
- **Reason propagation** (`shared/buildstatus`, both NATS publishers): the reason rides in an `X-Hades-Reason` NATS **header**; the payload stays the bare job ID, so `HadesLogManager` is untouched. `PublishJobStatus` gains a variadic `reason ...string`.
- **Docker executor** (`docker/scheduler.go`): already failed correctly; now also attaches the redacted, length-capped error as the reason.
- **Dashboard + SPA** (`dashboard.go`, `tracker.go`, `types.ts`, `job-detail.tsx`): reads the header, keeps `Reason` on the tracker/`JobSummary` (flows to list, detail, and SSE), and renders a callout on the job detail page.

No CRD or status-enum change - `Failed` carries the reason as a sibling field.

## 📌 Reason for the change / Link to issue

Stuck builds were invisible in the dashboard and their pods retried image pulls indefinitely in the cluster.

## 🧪 Steps for Testing

1. Submit a build whose step image does not exist.
2. Confirm the dashboard flips the job to **Failed** with a reason like `ImagePullBackOff: …` (instead of a perpetual "Running"), and that the underlying Kubernetes Job/pod is removed.

Automated: `make build`, `make lint` (0 issues), `make test` (all modules), and web `lint`/`test` (28 pass)/`build` all green. Added `podStuckReason` table test, `FirstReason`, and a tracker reason-retention test.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)