### PR TITLE
Restore secrets: inherit on the k8s deploy callers

### DIFF
--- a/.github/workflows/deploy-k8s-prod.yml
+++ b/.github/workflows/deploy-k8s-prod.yml
@@ -50,9 +50,12 @@ jobs:
 
   deploy:
     needs: validate
-    # No `secrets: inherit`: the reusable job reads its secrets from the k8s-prod
-    # environment it selects, so inheriting the caller's secrets would only widen exposure.
+    # `secrets: inherit` is REQUIRED: the reusable job reads environment secrets
+    # (KUBE_CONFIG, AUTH_KEY, DASHBOARD_*) from the k8s-prod environment it selects,
+    # and a reusable workflow only receives those when the caller inherits secrets -
+    # its own `environment:` declaration alone does not grant access.
     uses: ./.github/workflows/deploy-k8s.yml
+    secrets: inherit
     with:
       environment: k8s-prod
       namespace: hades

--- a/.github/workflows/deploy-k8s-test.yml
+++ b/.github/workflows/deploy-k8s-test.yml
@@ -17,9 +17,13 @@ permissions:
 
 jobs:
   deploy:
-    # No `secrets: inherit`: the reusable job reads its secrets from the k8s-test
-    # environment it selects, so inheriting the caller's secrets would only widen exposure.
+    # `secrets: inherit` is REQUIRED: the reusable job reads environment secrets
+    # (KUBE_CONFIG, AUTH_KEY, DASHBOARD_*) from the k8s-test environment it selects,
+    # and a reusable workflow only receives those when the caller inherits secrets -
+    # its own `environment:` declaration alone does not grant access. Without this the
+    # kubeconfig is empty and the deploy fails hitting localhost:8080.
     uses: ./.github/workflows/deploy-k8s.yml
+    secrets: inherit
     with:
       environment: k8s-test
       namespace: hades-test


### PR DESCRIPTION
## ✨ What is the change?

Restores `secrets: inherit` on the `deploy-k8s-prod.yml` and `deploy-k8s-test.yml` deploy jobs, reverting the removal in #489.

## 📌 Reason

Removing `secrets: inherit` broke the deploy. The reusable `deploy-k8s.yml` reads **environment** secrets (`KUBE_CONFIG`, `AUTH_KEY`, `DASHBOARD_*`) from the `k8s-*` environment it selects, but a reusable workflow only receives environment secrets when the caller inherits them - the job's own `environment:` declaration alone does **not** grant access. Without inherit, `KUBE_CONFIG` was empty and `kubectl` fell back to `localhost:8080`, failing at "Ensure namespace exists". Verified against run 32286212235.

The CodeRabbit least-privilege suggestion (#489) is incompatible with using environment secrets in a reusable workflow, so it's reverted.

## 🧪 Steps for Testing

Dispatch **Deploy to Kubernetes (test)**; it now reaches the cluster (kubeconfig resolves) and completes.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)