### PR TITLE
Docs: sync deploy + operator docs with recent changes

### DIFF
--- a/website/docs/deployment/kubernetes-github-actions.md
+++ b/website/docs/deployment/kubernetes-github-actions.md
@@ -32,10 +32,12 @@ Both are `workflow_dispatch` only - nothing deploys automatically. They call the
 6. **`helm upgrade --install --atomic`** with the base `values.yaml` plus the
    environment values file, pinning all four component image tags to the chosen version.
    `--atomic` rolls the release back on failure.
-7. **Restart `hades-api`** and wait for the rollout. The API reads `AUTH_KEY` and the
-   dashboard credentials as environment variables (resolved only at pod start), so a
-   redeploy that rotates those Secrets without changing the image tag would otherwise
-   leave the running pods on the old values.
+7. **Roll all four Hades deployments** and wait for each rollout. This covers the two
+   cases Helm does not roll on its own: a **mutable image tag** (`latest`, `pr-N`) whose
+   digest changed but whose tag string did not (Helm sees an unchanged spec, so the
+   restart re-pulls the new digest via `pullPolicy: Always`), and **rotated Secrets**
+   (`AUTH_KEY`, dashboard credentials) that pods read as environment variables only at
+   start. For an immutable release tag Helm already rolls, so the restart is a no-op.
 
 The `version` input maps directly to the container image tag (this repo tags images with
 the release tag verbatim, with no `v` prefix).

--- a/website/docs/operation-modes/k8s-operator.md
+++ b/website/docs/operation-modes/k8s-operator.md
@@ -21,7 +21,10 @@ The **Hades Operator** is the production-grade execution mode for Kubernetes. It
 The Operator introduces a `BuildJob` Custom Resource Definition (CRD). When the Scheduler receives a job (in `operator` mode), it creates a `BuildJob` resource instead of a Pod. The Operator's controller loop watches for `BuildJob` resources and:
 
 1. Creates a Kubernetes `Job` with one init-container per step plus a finalizer container.
-2. Monitors Pod status and updates the `BuildJob` status accordingly.
+2. Monitors Pod status and updates the `BuildJob` status accordingly. A pod wedged in a
+   terminal waiting state (e.g. `ImagePullBackOff` on a bad step image) is failed with the
+   reason recorded in the status and surfaced in the dashboard, and its `Job` is deleted so
+   it stops retrying.
 3. Publishes status transitions and logs back to NATS.
 4. Cleans up completed resources (configurable via `DeleteOnComplete`).
 


### PR DESCRIPTION
## ✨ What is the change?

Documentation-only sync after the recent deploy/operator changes:

- **`kubernetes-github-actions.md`** - the deploy step now describes rolling **all four** Hades deployments (not just `hades-api`), covering same-tag/mutable-tag redeploys (`latest`, `pr-N`) as well as Secret rotation. Matches the workflow after #496.
- **`k8s-operator.md`** - documents that the operator fails a pod stuck in a terminal waiting state (e.g. `ImagePullBackOff`) with the reason recorded/surfaced, and deletes its `Job`. Matches #492.

## 📌 Reason

Requested doc correctness check. Verified: no docs referenced the removed CI VM deploy, the Traefik/VM docs remain valid for the manual path, and no docs referenced the old `hades-clone-container` image.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)