### PR TITLE
Support per-build timeout, resource limits, network mode, and env vars

### DIFF
--- a/.github/workflows/deploy-k8s-test.yml
+++ b/.github/workflows/deploy-k8s-test.yml
@@ -1,7 +1,17 @@
 name: Deploy to Kubernetes (test)
 
 # Manual test deploy. Any image tag is allowed: `latest`, a release tag, a branch/sha
-# tag, or `pr-N`. The chart and CRDs come from the ref this workflow is run from.
+# tag, or `pr-N`.
+#
+# The chart and CRDs must match the deployed image - CRDs especially, since Helm never
+# upgrades them and the reusable workflow applies them from the chart source. To keep
+# them in sync with the image, the chart ref is resolved as follows:
+#   1. an explicit `chart-ref` input always wins;
+#   2. otherwise a `pr-N` version sources the chart/CRDs from that PR's head
+#      (refs/pull/N/head), so deploying a PR image also deploys that PR's CRDs;
+#   3. otherwise it falls back to the ref this workflow was dispatched from.
+# This avoids the trap of dispatching a `pr-N` image from `main`, which would deploy the
+# PR binaries against main's (stale) CRDs.
 
 on:
   workflow_dispatch:
@@ -11,12 +21,45 @@ on:
         required: true
         type: string
         default: latest
+      chart-ref:
+        description: "Git ref for the chart and CRDs. Empty = auto (PR head for pr-N, else the dispatched ref)."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
+  # Resolve which git ref the chart and CRDs should come from, so a `pr-N` image is
+  # always paired with that PR's chart/CRDs rather than the dispatched branch.
+  resolve-chart-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      chart-ref: ${{ steps.resolve.outputs.chart_ref }}
+    steps:
+      - id: resolve
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          CHART_REF_INPUT: ${{ inputs.chart-ref }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CHART_REF_INPUT" ]; then
+            # Explicit override always wins.
+            ref="$CHART_REF_INPUT"
+          elif [[ "$VERSION" =~ ^pr-([0-9]+)$ ]]; then
+            # Deploying a PR image: take the chart/CRDs from that PR's head commit.
+            ref="refs/pull/${BASH_REMATCH[1]}/head"
+          else
+            # Empty tells the reusable workflow to use the dispatched ref.
+            ref=""
+          fi
+          echo "chart_ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Resolved chart-ref for version '$VERSION': '${ref:-<dispatched ref>}'"
+
   deploy:
+    needs: resolve-chart-ref
     # `secrets: inherit` is REQUIRED: the reusable job reads environment secrets
     # (KUBE_CONFIG, AUTH_KEY, DASHBOARD_*) from the k8s-test environment it selects,
     # and a reusable workflow only receives those when the caller inherits secrets -
@@ -29,3 +72,4 @@ jobs:
       namespace: hades-test
       values-file: values-test.yaml
       image-tag: ${{ inputs.version }}
+      chart-ref: ${{ needs.resolve-chart-ref.outputs.chart-ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ Go workspace (`go.work`, Go 1.26) with five modules:
 - **Queue subjects:** `hades.jobs.{high,medium,low}` (priority-bucketed JetStream subjects).
 - **Status subjects:** `hades.jobstatus.{Queued,Running,Succeeded,Failed,Stopped}` (payload = job ID string). `HadesAPI` publishes `Queued` on enqueue; the scheduler/operator publish `Running`/`Succeeded`/`Failed`. `HadesLogManager` and the dashboard subscribe to the whole `hades.jobstatus.*` lifecycle.
 - **Log subjects:** see `shared/buildlogs/buildlog_stream.go`.
-- **Job DTO:** `shared/payload/payload.go` (`QueuePayload` with ordered `Step`s; each step has `image`, optional `script`, `metadata` env vars, `cpu_limit`, `memory_limit`).
+- **Job DTO:** `shared/payload/payload.go` (`QueuePayload` with ordered `Step`s). Job-level: `timeout_seconds` (whole-job timeout). Each step has `image`, optional `script`, `metadata` env vars, `cpu_limit` (whole cores), `memory_limit`, and the Docker-only limits `network`, `memory_swap`, `pids_limit`.
+  - **Executor parity:** `timeout_seconds`, env (`metadata`), `cpu_limit`, `memory_limit` are enforced on both executors (Kubernetes: per-container resources + Job `activeDeadlineSeconds`). `network`, `memory_swap`, `pids_limit` are enforced on the **Docker executor only**; the operator accepts them for schema parity but does not apply them (pod containers share a network namespace; no per-container swap/PID field).
 - **CRD:** `BuildJob` in `HadesScheduler/HadesOperator/api/v1/buildjob_types.go`. **Important:** if you change `BuildJobSpec`, run `make -C HadesScheduler/HadesOperator manifests generate` and commit `helm/hades/crds/build.hades.tum.de_buildjobs.yaml` and `zz_generated.deepcopy.go` - the `verify-crd.yml` GitHub workflow will fail otherwise. The `BuildJobSpec` is intentionally duplicated from `shared/payload`; keep them in sync manually.
 
 ## Build / test

--- a/HadesAPI/dashboard/handlers.go
+++ b/HadesAPI/dashboard/handlers.go
@@ -30,15 +30,19 @@ type StepView struct {
 	Metadata        map[string]string `json:"metadata"`
 	CPULimit        uint              `json:"cpuLimit"`
 	MemoryLimit     string            `json:"memoryLimit"`
+	Network         string            `json:"network,omitempty"`
+	MemorySwap      string            `json:"memorySwap,omitempty"`
+	PidsLimit       int64             `json:"pidsLimit,omitempty"`
 }
 
 // JobDetail is the full job view: identity/status from the tracker plus the
 // redacted payload from the KV store.
 type JobDetail struct {
 	JobSummary
-	Timestamp time.Time         `json:"timestamp"`
-	Metadata  map[string]string `json:"metadata"`
-	Steps     []StepView        `json:"steps"`
+	Timestamp      time.Time         `json:"timestamp"`
+	Metadata       map[string]string `json:"metadata"`
+	Steps          []StepView        `json:"steps"`
+	TimeoutSeconds int64             `json:"timeoutSeconds,omitempty"`
 	// PayloadAvailable is false when the full payload has aged out of the KV
 	// store; identity/status from the tracker are still returned.
 	PayloadAvailable bool `json:"payloadAvailable"`
@@ -132,6 +136,7 @@ func (s *Server) handleJobDetail(c *gin.Context) {
 	}
 	detail.PayloadAvailable = true
 	detail.Timestamp = job.Timestamp
+	detail.TimeoutSeconds = job.TimeoutSeconds
 	if detail.Name == "" {
 		detail.Name = job.Name
 	}
@@ -151,6 +156,9 @@ func (s *Server) handleJobDetail(c *gin.Context) {
 			Metadata:        nonNil(st.Metadata),
 			CPULimit:        st.CPULimit,
 			MemoryLimit:     st.MemoryLimit,
+			Network:         st.Network,
+			MemorySwap:      st.MemorySwap,
+			PidsLimit:       st.PidsLimit,
 		}
 	}
 

--- a/HadesAPI/docs/docs.go
+++ b/HadesAPI/docs/docs.go
@@ -131,6 +131,10 @@ const docTemplate = `{
                         "$ref": "#/definitions/payload.Step"
                     }
                 },
+                "timeout_seconds": {
+                    "description": "Whole-job timeout in seconds; the job is killed and marked failed once exceeded. 0 = no timeout.",
+                    "type": "integer"
+                },
                 "timestamp": {
                     "description": "Job creation timestamp",
                     "type": "string"
@@ -145,7 +149,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "cpu_limit": {
-                    "description": "CPU limit in millicores (e.g., 1000 = 1 CPU core)",
+                    "description": "CPU limit in whole cores (e.g., 1 = 1 CPU core, 2 = 2 cores)",
                     "type": "integer"
                 },
                 "id": {
@@ -160,6 +164,10 @@ const docTemplate = `{
                     "description": "Memory limit (e.g., \"512M\", \"2G\")",
                     "type": "string"
                 },
+                "memory_swap": {
+                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); must be \u003e= memory_limit. Docker executor only.",
+                    "type": "string"
+                },
                 "metadata": {
                     "description": "Step-specific environment variables and metadata",
                     "type": "object",
@@ -170,6 +178,14 @@ const docTemplate = `{
                 "name": {
                     "description": "Human-readable step name",
                     "type": "string"
+                },
+                "network": {
+                    "description": "Docker network mode: \"none\", \"bridge\", \"host\", \"default\", or a named network. Empty = executor default. Docker executor only; accepted but not enforced on Kubernetes.",
+                    "type": "string"
+                },
+                "pids_limit": {
+                    "description": "Maximum number of PIDs in the container; 0 = unlimited. Docker executor only.",
+                    "type": "integer"
                 },
                 "script": {
                     "description": "Shell script to execute in the container",

--- a/HadesAPI/docs/docs.go
+++ b/HadesAPI/docs/docs.go
@@ -165,7 +165,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "memory_swap": {
-                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); must be \u003e= memory_limit. Docker executor only.",
+                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); requires memory_limit to be set and must be \u003e= memory_limit. Docker executor only.",
                     "type": "string"
                 },
                 "metadata": {

--- a/HadesAPI/docs/swagger.json
+++ b/HadesAPI/docs/swagger.json
@@ -124,6 +124,10 @@
                         "$ref": "#/definitions/payload.Step"
                     }
                 },
+                "timeout_seconds": {
+                    "description": "Whole-job timeout in seconds; the job is killed and marked failed once exceeded. 0 = no timeout.",
+                    "type": "integer"
+                },
                 "timestamp": {
                     "description": "Job creation timestamp",
                     "type": "string"
@@ -138,7 +142,7 @@
                     "type": "boolean"
                 },
                 "cpu_limit": {
-                    "description": "CPU limit in millicores (e.g., 1000 = 1 CPU core)",
+                    "description": "CPU limit in whole cores (e.g., 1 = 1 CPU core, 2 = 2 cores)",
                     "type": "integer"
                 },
                 "id": {
@@ -153,6 +157,10 @@
                     "description": "Memory limit (e.g., \"512M\", \"2G\")",
                     "type": "string"
                 },
+                "memory_swap": {
+                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); must be \u003e= memory_limit. Docker executor only.",
+                    "type": "string"
+                },
                 "metadata": {
                     "description": "Step-specific environment variables and metadata",
                     "type": "object",
@@ -163,6 +171,14 @@
                 "name": {
                     "description": "Human-readable step name",
                     "type": "string"
+                },
+                "network": {
+                    "description": "Docker network mode: \"none\", \"bridge\", \"host\", \"default\", or a named network. Empty = executor default. Docker executor only; accepted but not enforced on Kubernetes.",
+                    "type": "string"
+                },
+                "pids_limit": {
+                    "description": "Maximum number of PIDs in the container; 0 = unlimited. Docker executor only.",
+                    "type": "integer"
                 },
                 "script": {
                     "description": "Shell script to execute in the container",

--- a/HadesAPI/docs/swagger.json
+++ b/HadesAPI/docs/swagger.json
@@ -158,7 +158,7 @@
                     "type": "string"
                 },
                 "memory_swap": {
-                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); must be \u003e= memory_limit. Docker executor only.",
+                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); requires memory_limit to be set and must be \u003e= memory_limit. Docker executor only.",
                     "type": "string"
                 },
                 "metadata": {

--- a/HadesAPI/docs/swagger.yaml
+++ b/HadesAPI/docs/swagger.yaml
@@ -55,7 +55,8 @@ definitions:
         type: string
       memory_swap:
         description: Total memory+swap limit, same format as memory_limit (e.g., "512M",
-          "2G"); must be >= memory_limit. Docker executor only.
+          "2G"); requires memory_limit to be set and must be >= memory_limit. Docker
+          executor only.
         type: string
       metadata:
         additionalProperties:

--- a/HadesAPI/docs/swagger.yaml
+++ b/HadesAPI/docs/swagger.yaml
@@ -26,6 +26,10 @@ definitions:
         items:
           $ref: '#/definitions/payload.Step'
         type: array
+      timeout_seconds:
+        description: Whole-job timeout in seconds; the job is killed and marked failed
+          once exceeded. 0 = no timeout.
+        type: integer
       timestamp:
         description: Job creation timestamp
         type: string
@@ -38,7 +42,7 @@ definitions:
         description: Whether to continue with the next step if this step fails
         type: boolean
       cpu_limit:
-        description: CPU limit in millicores (e.g., 1000 = 1 CPU core)
+        description: CPU limit in whole cores (e.g., 1 = 1 CPU core, 2 = 2 cores)
         type: integer
       id:
         description: Step execution order (starts at 1)
@@ -49,6 +53,10 @@ definitions:
       memory_limit:
         description: Memory limit (e.g., "512M", "2G")
         type: string
+      memory_swap:
+        description: Total memory+swap limit, same format as memory_limit (e.g., "512M",
+          "2G"); must be >= memory_limit. Docker executor only.
+        type: string
       metadata:
         additionalProperties:
           type: string
@@ -57,6 +65,15 @@ definitions:
       name:
         description: Human-readable step name
         type: string
+      network:
+        description: 'Docker network mode: "none", "bridge", "host", "default", or
+          a named network. Empty = executor default. Docker executor only; accepted
+          but not enforced on Kubernetes.'
+        type: string
+      pids_limit:
+        description: Maximum number of PIDs in the container; 0 = unlimited. Docker
+          executor only.
+        type: integer
       script:
         description: Shell script to execute in the container
         type: string

--- a/HadesAPI/router.go
+++ b/HadesAPI/router.go
@@ -172,6 +172,11 @@ func addBuildToQueue(c *gin.Context, producer hades.JobPublisher, statusPublishe
 		c.String(http.StatusBadRequest, "timeout_seconds cannot be negative")
 		return
 	}
+	if p.QueuePayload.TimeoutSeconds > payload.MaxTimeoutSeconds {
+		slog.Error("timeout_seconds too large", "value", p.QueuePayload.TimeoutSeconds)
+		c.String(http.StatusBadRequest, fmt.Sprintf("timeout_seconds must not exceed %d", payload.MaxTimeoutSeconds))
+		return
+	}
 
 	for _, step := range p.QueuePayload.Steps {
 		var memLimitBytes int64

--- a/HadesAPI/router.go
+++ b/HadesAPI/router.go
@@ -167,13 +167,52 @@ func addBuildToQueue(c *gin.Context, producer hades.JobPublisher, statusPublishe
 		return
 	}
 
+	if p.QueuePayload.TimeoutSeconds < 0 {
+		slog.Error("Invalid timeout_seconds", "value", p.QueuePayload.TimeoutSeconds)
+		c.String(http.StatusBadRequest, "timeout_seconds cannot be negative")
+		return
+	}
+
 	for _, step := range p.QueuePayload.Steps {
+		var memLimitBytes int64
 		if step.MemoryLimit != "" {
-			if _, err := utils.ParseMemoryLimit(step.MemoryLimit); err != nil {
+			parsed, err := utils.ParseMemoryLimit(step.MemoryLimit)
+			if err != nil {
 				slog.Error("Failed to parse RAM limit", "error", err)
 				c.String(http.StatusBadRequest, "Failed to parse RAM limit")
 				return
 			}
+			memLimitBytes = parsed
+		}
+
+		if step.MemorySwap != "" {
+			swapBytes, err := utils.ParseMemoryLimit(step.MemorySwap)
+			if err != nil {
+				slog.Error("Failed to parse memory_swap limit", "error", err)
+				c.String(http.StatusBadRequest, "Failed to parse memory_swap limit")
+				return
+			}
+			// Docker requires memory_swap (total memory+swap) to be set together
+			// with a memory limit and to be at least as large as it.
+			if step.MemoryLimit == "" {
+				c.String(http.StatusBadRequest, "memory_swap requires memory_limit to be set")
+				return
+			}
+			if swapBytes < memLimitBytes {
+				c.String(http.StatusBadRequest, "memory_swap must be greater than or equal to memory_limit")
+				return
+			}
+		}
+
+		if step.PidsLimit < 0 {
+			c.String(http.StatusBadRequest, "pids_limit cannot be negative")
+			return
+		}
+
+		if err := utils.ValidateNetworkMode(step.Network); err != nil {
+			slog.Error("Invalid network mode", "error", err)
+			c.String(http.StatusBadRequest, err.Error())
+			return
 		}
 	}
 

--- a/HadesAPI/router_test.go
+++ b/HadesAPI/router_test.go
@@ -273,6 +273,12 @@ func (suite *APISuite) TestNegativeTimeoutSeconds() {
 	assert.Contains(suite.T(), w.Body.String(), "timeout_seconds")
 }
 
+func (suite *APISuite) TestTimeoutSecondsTooLarge() {
+	w := suite.postStep(payload.Step{ID: 1, Name: "s", Image: "image1"}, payload.MaxTimeoutSeconds+1)
+	assert.Equal(suite.T(), 400, w.Code)
+	assert.Contains(suite.T(), w.Body.String(), "timeout_seconds")
+}
+
 func (suite *APISuite) TestValidCallbackURL() {
 	w := httptest.NewRecorder()
 	restPayload := payload.RESTPayload{

--- a/HadesAPI/router_test.go
+++ b/HadesAPI/router_test.go
@@ -230,6 +230,49 @@ func (suite *APISuite) TestInvalidMemoryLimit() {
 	assert.Equal(suite.T(), "Failed to parse RAM limit", w.Body.String())
 }
 
+// postStep is a helper that submits a single-step job and returns the response.
+func (suite *APISuite) postStep(step payload.Step, timeoutSeconds int64) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	restPayload := payload.RESTPayload{
+		Priority: 1,
+		QueuePayload: payload.QueuePayload{
+			Name:           "example",
+			Timestamp:      time.Now(),
+			TimeoutSeconds: timeoutSeconds,
+			Steps:          []payload.Step{step},
+		},
+	}
+	jsonValue, _ := json.Marshal(restPayload)
+	req, _ := http.NewRequest("POST", "/build", bytes.NewBuffer(jsonValue))
+	req.Header.Set("Content-Type", "application/json")
+	suite.router.ServeHTTP(w, req)
+	return w
+}
+
+func (suite *APISuite) TestInvalidNetworkMode() {
+	w := suite.postStep(payload.Step{ID: 1, Name: "s", Image: "image1", Network: "bad net"}, 0)
+	assert.Equal(suite.T(), 400, w.Code)
+	assert.Contains(suite.T(), w.Body.String(), "network")
+}
+
+func (suite *APISuite) TestMemorySwapRequiresMemoryLimit() {
+	w := suite.postStep(payload.Step{ID: 1, Name: "s", Image: "image1", MemorySwap: "2G"}, 0)
+	assert.Equal(suite.T(), 400, w.Code)
+	assert.Contains(suite.T(), w.Body.String(), "memory_swap requires memory_limit")
+}
+
+func (suite *APISuite) TestMemorySwapSmallerThanMemoryLimit() {
+	w := suite.postStep(payload.Step{ID: 1, Name: "s", Image: "image1", MemoryLimit: "2G", MemorySwap: "1G"}, 0)
+	assert.Equal(suite.T(), 400, w.Code)
+	assert.Contains(suite.T(), w.Body.String(), "memory_swap must be greater than or equal to memory_limit")
+}
+
+func (suite *APISuite) TestNegativeTimeoutSeconds() {
+	w := suite.postStep(payload.Step{ID: 1, Name: "s", Image: "image1"}, -5)
+	assert.Equal(suite.T(), 400, w.Code)
+	assert.Contains(suite.T(), w.Body.String(), "timeout_seconds")
+}
+
 func (suite *APISuite) TestValidCallbackURL() {
 	w := httptest.NewRecorder()
 	restPayload := payload.RESTPayload{

--- a/HadesScheduler/HadesOperator/api/v1/buildjob_types.go
+++ b/HadesScheduler/HadesOperator/api/v1/buildjob_types.go
@@ -126,6 +126,22 @@ type BuildStep struct {
 	// Prevents out-of-memory issues and resource exhaustion.
 	// If not specified, uses cluster defaults.
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
+
+	// Docker network mode for this step (e.g. "none", "bridge", "host", or a named network).
+	// Docker executor only: accepted for schema parity but NOT enforced on Kubernetes,
+	// where all containers in a pod share a single network namespace.
+	Network string `json:"network,omitempty"`
+
+	// Total memory+swap limit (e.g. "512M", "2G"), matching the Docker semantics where
+	// this is memory + swap combined.
+	// Docker executor only: accepted for schema parity but NOT enforced on Kubernetes,
+	// which has no per-container swap field.
+	MemorySwap string `json:"memorySwap,omitempty"`
+
+	// Maximum number of PIDs allowed in this step's container; 0 means unlimited.
+	// Docker executor only: accepted for schema parity but NOT enforced on Kubernetes,
+	// which has no per-container PID-limit field.
+	PidsLimit int64 `json:"pidsLimit,omitempty"`
 }
 
 type BuildJobStatus struct {

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_build_test.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_build_test.go
@@ -156,3 +156,44 @@ func TestBuildK8sJob_NoDuplicateStepScriptEnv(t *testing.T) {
 		t.Errorf("HADES_STEP_SCRIPT = %q (present=%v), want %q (reserved value wins over metadata)", got, ok, script)
 	}
 }
+
+// The whole-job timeout must be enforced via the Job's ActiveDeadlineSeconds so
+// Kubernetes fails the Job (reason DeadlineExceeded) once it elapses.
+func TestBuildK8sJob_ActiveDeadlineSeconds(t *testing.T) {
+	timeout := int64(600)
+	bj := &buildv1.BuildJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1"},
+		Spec: buildv1.BuildJobSpec{
+			Name:           "job-1",
+			TimeoutSeconds: &timeout,
+			Steps: []buildv1.BuildStep{
+				{ID: 1, Name: "run", Image: "alpine", Script: "echo hi"},
+			},
+		},
+	}
+
+	job := buildK8sJob(bj, "job-1", true, false)
+	if job.Spec.ActiveDeadlineSeconds == nil {
+		t.Fatalf("ActiveDeadlineSeconds not set, want %d", timeout)
+	}
+	if *job.Spec.ActiveDeadlineSeconds != timeout {
+		t.Errorf("ActiveDeadlineSeconds = %d, want %d", *job.Spec.ActiveDeadlineSeconds, timeout)
+	}
+}
+
+// When no timeout is configured, ActiveDeadlineSeconds must stay nil so the Job
+// has no deadline (current default behaviour).
+func TestBuildK8sJob_NoTimeoutLeavesDeadlineUnset(t *testing.T) {
+	bj := &buildv1.BuildJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1"},
+		Spec: buildv1.BuildJobSpec{
+			Name:  "job-1",
+			Steps: []buildv1.BuildStep{{ID: 1, Name: "run", Image: "alpine", Script: "echo hi"}},
+		},
+	}
+
+	job := buildK8sJob(bj, "job-1", true, false)
+	if job.Spec.ActiveDeadlineSeconds != nil {
+		t.Errorf("ActiveDeadlineSeconds = %v, want nil", *job.Spec.ActiveDeadlineSeconds)
+	}
+}

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
@@ -150,6 +150,33 @@ func (r *BuildJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// while a terminated container's live log stream is still publishing.
 		draining, pod, err := r.updateContainerStatuses(ctx, &bj)
 		if err != nil {
+			// When a Job hits its activeDeadlineSeconds (whole-job timeout),
+			// Kubernetes marks the Job Failed (reason DeadlineExceeded) and deletes
+			// its pod. The pod is then unresolvable and the status update fails - but
+			// the Job condition already tells us the outcome, so finalize from it
+			// instead of requeueing this error forever. The pod (and thus its logs)
+			// is already gone, so there is nothing left to drain.
+			if done, succeeded, msg := jobFinished(&existingJob); done {
+				slog.Warn("Container status update failed but Job already finished; finalizing", "buildJob", bj.Name, "reason", msg)
+				if serr := r.setStatusCompleted(ctx, req.NamespacedName, bj.Name, succeeded, msg); serr != nil {
+					if apierrors.IsConflict(serr) {
+						return ctrl.Result{RequeueAfter: conflictRequeueDelay}, nil
+					}
+					return ctrl.Result{}, serr
+				}
+				r.logStreams().stopJob(bj.Namespace, bj.Name)
+				if r.DeleteOnComplete {
+					policy := metav1.DeletePropagationForeground
+					if derr := r.Delete(ctx, &bj, &client.DeleteOptions{PropagationPolicy: &policy}); derr != nil && !apierrors.IsNotFound(derr) {
+						return ctrl.Result{}, derr
+					}
+				}
+				if aerr := r.admitOneSuspendedJob(ctx, bj.Namespace); aerr != nil {
+					slog.Error("Failed to admit suspended job after timeout finalization", "error", aerr)
+				}
+				return ctrl.Result{}, nil
+			}
+
 			// draining is unreliable when the status update failed, so requeue
 			// instead of proceeding: finalizing here could delete the pod while a
 			// container's log stream is still draining and lose its tail logs.
@@ -533,6 +560,13 @@ func buildK8sJob(bj *buildv1.BuildJob, jobName string, deleteOnComplete bool, su
 			}
 		}
 
+		// NOTE: s.Network, s.MemorySwap and s.PidsLimit are intentionally NOT applied
+		// here. They are Docker-executor-only: Kubernetes has no per-container swap or
+		// PID-limit field, and all containers in a pod share one network namespace, so
+		// per-step network isolation is not expressible. These fields are accepted for
+		// schema parity with the Docker executor only. The whole-job timeout is enforced
+		// via Job.spec.activeDeadlineSeconds (see below).
+
 		initCtrs = append(initCtrs, c)
 	}
 
@@ -583,6 +617,10 @@ func buildK8sJob(bj *buildv1.BuildJob, jobName string, deleteOnComplete bool, su
 			Suspend:                 &suspend,
 			TTLSecondsAfterFinished: ttl,
 			BackoffLimit:            &backoff,
+			// Whole-job timeout: Kubernetes fails the Job (reason DeadlineExceeded)
+			// and deletes its pod once this elapses, covering time spent in init
+			// containers (the build steps). nil when no timeout is configured.
+			ActiveDeadlineSeconds: bj.Spec.TimeoutSeconds,
 			Template: corev1.PodTemplateSpec{
 				Spec: podSpec,
 			},

--- a/HadesScheduler/docker/docker.go
+++ b/HadesScheduler/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"sync"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/hades-scheduler/hades/hadesScheduler/log"
 	"github.com/hades-scheduler/hades/shared/buildlogs"
 	"github.com/moby/moby/api/pkg/stdcopy"
@@ -58,6 +59,11 @@ func removeContainer(ctx context.Context, cli *client.Client, containerID string
 		Force:         true, // Kill if running, then remove
 		RemoveVolumes: true, // Clean up any volumes
 	}); err != nil {
+		// The container may already be gone (e.g. AutoRemove reaped it, or it was
+		// removed on a prior cleanup): treat that as success rather than a noisy error.
+		if cerrdefs.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to cleanup container %s: %w", containerID, err)
 	}
 

--- a/HadesScheduler/docker/job.go
+++ b/HadesScheduler/docker/job.go
@@ -56,6 +56,12 @@ func (d Job) execute(ctx context.Context) error {
 		err := dockerStep.execute(stepCtx)
 		if err != nil {
 			d.logger.Error("Failed to execute step", slog.Any("error", err))
+			// A cancelled/expired job context (e.g. the whole-job timeout) must
+			// abort the job immediately, even for ContinueOnError steps - otherwise
+			// a timeout would be swallowed and later steps would keep running.
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			if step.ContinueOnError {
 				d.logger.Info("Next step should be executed despite error due to ContinueOnError setting", slog.Any("step", step))
 				stepErr = errors.Join(stepErr, fmt.Errorf("step %v failed with ContinueOnError set: %w", step.ID, err))

--- a/HadesScheduler/docker/scheduler.go
+++ b/HadesScheduler/docker/scheduler.go
@@ -146,16 +146,34 @@ func (d *Scheduler) ScheduleJob(ctx context.Context, job payload.QueuePayload) e
 		jobLogger.Warn("failed to publish running status", "error", err)
 	}
 
-	err := dockerJob.execute(ctx)
+	// Apply the whole-job timeout, if configured. When it fires, the derived
+	// context is cancelled, which unblocks the running step's ContainerWait and
+	// triggers its force-cleanup so no container is left running.
+	execCtx := ctx
+	if job.TimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		execCtx, cancel = context.WithTimeout(ctx, time.Duration(job.TimeoutSeconds)*time.Second)
+		defer cancel()
+	}
+
+	err := dockerJob.execute(execCtx)
 	if err != nil {
 		// Surface why the job failed (e.g. an image pull error) to the dashboard.
 		// Redact secret-looking tokens and cap the length so a verbose daemon error
 		// stays within NATS header limits.
 		reason := redact.Default().Text(err.Error())
+		// Distinguish a timeout from other failures for a clearer status message.
+		// The parent ctx being live while execCtx is done means the job timed out
+		// rather than the whole scheduler shutting down.
+		if job.TimeoutSeconds > 0 && execCtx.Err() != nil && ctx.Err() == nil {
+			reason = fmt.Sprintf("job timed out after %d seconds", job.TimeoutSeconds)
+		}
 		if runes := []rune(reason); len(runes) > maxStatusReasonLen {
 			reason = string(runes[:maxStatusReasonLen]) + "…"
 		}
-		if perr := d.statusPublisher.PublishJobStatus(ctx, buildstatus.StatusFailed, job.ID.String(), reason); perr != nil {
+		// Publish with a fresh context: the job ctx may already be cancelled (on a
+		// timeout), which would otherwise drop the failure status.
+		if perr := d.statusPublisher.PublishJobStatus(context.WithoutCancel(ctx), buildstatus.StatusFailed, job.ID.String(), reason); perr != nil {
 			jobLogger.Warn("failed to publish failed status", "error", perr)
 		}
 		jobLogger.Error("Failed to execute job", "error", err)

--- a/HadesScheduler/docker/scheduler.go
+++ b/HadesScheduler/docker/scheduler.go
@@ -151,8 +151,15 @@ func (d *Scheduler) ScheduleJob(ctx context.Context, job payload.QueuePayload) e
 	// triggers its force-cleanup so no container is left running.
 	execCtx := ctx
 	if job.TimeoutSeconds > 0 {
+		// Clamp to the overflow-safe bound (the API rejects larger values, but a
+		// payload may reach the scheduler from other producers): seconds *
+		// time.Second must not overflow int64 nanoseconds into a negative duration.
+		timeoutSeconds := job.TimeoutSeconds
+		if timeoutSeconds > payload.MaxTimeoutSeconds {
+			timeoutSeconds = payload.MaxTimeoutSeconds
+		}
 		var cancel context.CancelFunc
-		execCtx, cancel = context.WithTimeout(ctx, time.Duration(job.TimeoutSeconds)*time.Second)
+		execCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 		defer cancel()
 	}
 

--- a/HadesScheduler/docker/scheduler_test.go
+++ b/HadesScheduler/docker/scheduler_test.go
@@ -128,6 +128,65 @@ func TestScheduleJobFailsOnNonZeroExit(t *testing.T) {
 	require.NotContains(t, joined, "should-not-run")
 }
 
+// TestScheduleJobTimesOut asserts the whole-job timeout kills a long-running
+// step, fails the job promptly, and leaves no container running (so the shared
+// volume can be cleaned up).
+func TestScheduleJobTimesOut(t *testing.T) {
+	publisher := &capturingPublisher{}
+	scheduler := newTestScheduler(t, publisher)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	job := payload.QueuePayload{
+		ID:             uuid.New(),
+		Name:           "timeout-job",
+		TimeoutSeconds: 2,
+		Steps: []payload.Step{
+			{ID: 1, Image: testImage, Script: "sleep 120"},
+		},
+	}
+
+	start := time.Now()
+	err := scheduler.ScheduleJob(ctx, job)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// The job must abort near the 2s deadline, not run the full 120s sleep.
+	require.Less(t, elapsed, 60*time.Second, "job did not abort at the timeout")
+
+	// No container for this job may still be running: a cancelled ContainerWait
+	// does not stop the container, so the executor must force-remove it.
+	list, listErr := scheduler.cli.ContainerList(ctx, client.ContainerListOptions{
+		All:     true,
+		Filters: client.Filters{}.Add("label", "job_id="+job.ID.String()),
+	})
+	require.NoError(t, listErr)
+	require.Empty(t, list.Items, "container was leaked after timeout")
+}
+
+// TestScheduleJobNetworkNone asserts that network mode "none" fully isolates the
+// step container: only the loopback interface is present.
+func TestScheduleJobNetworkNone(t *testing.T) {
+	publisher := &capturingPublisher{}
+	scheduler := newTestScheduler(t, publisher)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// With network "none" the only network interface is "lo"; any other interface
+	// (e.g. eth0 on the default bridge) makes this fail.
+	job := payload.QueuePayload{
+		ID:   uuid.New(),
+		Name: "network-none-job",
+		Steps: []payload.Step{
+			{ID: 1, Image: testImage, Network: "none", Script: `test "$(ls /sys/class/net)" = "lo"`},
+		},
+	}
+
+	require.NoError(t, scheduler.ScheduleJob(ctx, job))
+}
+
 // TestPullImagesReportsErrorForMissingImage asserts that errors the daemon
 // reports in-band on the pull stream surface as errors rather than being
 // silently drained.

--- a/HadesScheduler/docker/step.go
+++ b/HadesScheduler/docker/step.go
@@ -84,6 +84,29 @@ func (s Step) execute(ctx context.Context) error {
 		hostConfig.Resources.Memory = ramLimit
 	}
 
+	// Total memory+swap limit. Validated at submission time to be >= the memory
+	// limit and to require a memory limit, so it is safe to set directly here.
+	if s.MemorySwap != "" {
+		swapLimit, err := utils.ParseMemoryLimit(s.MemorySwap)
+		if err != nil {
+			return fmt.Errorf("parsing memory_swap: %w", err)
+		}
+		s.logger.Debug("Setting memory+swap limit to ", "limit", swapLimit)
+		hostConfig.Resources.MemorySwap = swapLimit
+	}
+
+	if s.PidsLimit > 0 {
+		s.logger.Debug("Setting PIDs limit to ", "limit", s.PidsLimit)
+		hostConfig.Resources.PidsLimit = &s.PidsLimit
+	}
+
+	// Network mode (e.g. "none" to fully disable networking). Empty means the
+	// Docker default. Validated at submission time.
+	if s.Network != "" {
+		s.logger.Debug("Setting network mode to ", "network", s.Network)
+		hostConfig.NetworkMode = container.NetworkMode(s.Network)
+	}
+
 	// Create the bash script if there is one
 	if s.Script != "" {
 		// Overwrite the default entrypoint
@@ -101,6 +124,19 @@ func (s Step) execute(ctx context.Context) error {
 	}
 
 	defer func() {
+		// If the job context was cancelled (e.g. a timeout) the container may
+		// still be running: AutoRemove only reaps containers that have already
+		// exited, and the cancelled job ctx can no longer drive cleanup. Force
+		// remove with a fresh context so the container is stopped and the shared
+		// volume is released, regardless of the AutoRemove setting.
+		if ctx.Err() != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+			if err := removeContainer(cleanupCtx, s.cli, resp.ID); err != nil {
+				s.logger.Error("Failed to cleanup container after cancellation", slog.Any("error", err), slog.Any("container_id", resp.ID))
+			}
+			return
+		}
 		if s.Options.containerAutoremove {
 			return
 		}

--- a/HadesScheduler/go.mod
+++ b/HadesScheduler/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 replace github.com/hades-scheduler/hades/shared => ../shared
 
 require (
+	github.com/containerd/errdefs v1.0.0
 	github.com/hades-scheduler/hades/shared v0.0.0-20260731094431-f95c1b4a6d91
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
@@ -20,7 +21,6 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
 	github.com/go-openapi/swag/cmdutils v0.28.0 // indirect

--- a/HadesScheduler/k8s/k8s.go
+++ b/HadesScheduler/k8s/k8s.go
@@ -180,7 +180,30 @@ func buildBuildJobObject(job payload.QueuePayload, namespace string) *unstructur
 		if s.MemoryLimit != "" {
 			sm["memoryLimit"] = s.MemoryLimit
 		}
+		// network, memorySwap and pidsLimit are forwarded for schema symmetry with
+		// the Docker executor, but the operator does not enforce them on the pod
+		// (Kubernetes has no per-container field for swap/pids, and all containers
+		// in a pod share one network namespace). See buildK8sJob.
+		if s.Network != "" {
+			sm["network"] = s.Network
+		}
+		if s.MemorySwap != "" {
+			sm["memorySwap"] = s.MemorySwap
+		}
+		if s.PidsLimit > 0 {
+			sm["pidsLimit"] = s.PidsLimit
+		}
 		steps = append(steps, sm)
+	}
+
+	spec := map[string]interface{}{
+		"name":     job.Name,
+		"metadata": job.Metadata,
+		"steps":    steps,
+	}
+	// Whole-job timeout, enforced by the operator via Job.spec.activeDeadlineSeconds.
+	if job.TimeoutSeconds > 0 {
+		spec["timeoutSeconds"] = job.TimeoutSeconds
 	}
 
 	return &unstructured.Unstructured{
@@ -192,11 +215,7 @@ func buildBuildJobObject(job payload.QueuePayload, namespace string) *unstructur
 				"namespace": namespace,
 				"labels":    labels,
 			},
-			"spec": map[string]interface{}{
-				"name":     job.Name,
-				"metadata": job.Metadata,
-				"steps":    steps,
-			},
+			"spec": spec,
 		},
 	}
 }

--- a/bruno/api/Create Build Job (Resource Limits).bru
+++ b/bruno/api/Create Build Job (Resource Limits).bru
@@ -1,0 +1,57 @@
+meta {
+  name: Create Build Job (Resource Limits)
+  type: http
+  seq: 20
+}
+
+post {
+  url: http://{{hostname}}/build
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: hades
+  password: {{auth_key}}
+}
+
+body:json {
+  {
+    "name": "Resource-Limited Job",
+    "metadata": {
+      "GLOBAL": "test"
+    },
+    "timestamp": "2021-01-01T00:00:00.000Z",
+    "priority": 3,
+    "timeout_seconds": 600, // whole-job timeout; job is killed + failed once exceeded (both executors)
+    "steps": [
+      {
+        "id": 1,
+        "name": "Clone",
+        "image": "ghcr.io/hades-scheduler/git-container:1.0.0",
+        "metadata": {
+          "REPOSITORY_DIR": "/shared"
+        }
+      },
+      {
+        "id": 2,
+        "name": "Execute",
+        "image": "ls1tum/artemis-maven-template:java17-18",
+        "script": "set -e && cd /shared/example && ./gradlew clean test",
+        "cpu_limit": 2,            // whole cores (both executors)
+        "memory_limit": "2G",      // both executors
+        "metadata": {              // env vars for the step (both executors)
+          "BUILD_ENV": "ci"
+        },
+        "network": "none",         // Docker executor only (K8s: accepted, not enforced)
+        "memory_swap": "2G",       // Docker executor only; must be >= memory_limit
+        "pids_limit": 512          // Docker executor only
+      }
+    ]
+  }
+}
+
+vars:pre-request {
+  user:
+  password:
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -101,6 +101,8 @@ Submitted to `POST /build`. Field semantics come from `shared/payload/payload.go
 | `timestamp` | RFC3339 | no | Job creation time. |
 | `metadata` | map[string]string | no | Job-level metadata (also injected as environment variables). |
 | `steps` | `[]Step` | no | Ordered steps to execute. |
+| `callback_url` | string | no | Absolute http/https URL to forward aggregated logs/results to. |
+| `timeout_seconds` | int64 | no | Whole-job timeout in seconds. The job is killed and marked failed once exceeded. `0` (default) = no timeout. Enforced on both executors (Docker: context deadline; Kubernetes: Job `activeDeadlineSeconds`). |
 
 ### `Step`
 
@@ -112,10 +114,17 @@ Submitted to `POST /build`. Field semantics come from `shared/payload/payload.go
 | `script` | string | Shell script to run in the container. |
 | `continue_on_error` | bool | Continue with the next step if this one fails. |
 | `metadata` | map[string]string | Step-specific environment variables. |
-| `cpu_limit` | uint | CPU limit in millicores (e.g. `1000` = 1 core). |
+| `cpu_limit` | uint | CPU limit in whole cores (e.g. `1` = 1 core, `2` = 2 cores). |
 | `memory_limit` | string | Memory limit, e.g. `512M`, `2G`. |
+| `network` | string | Docker network mode: `none`, `bridge`, `host`, `default`, or a named network. Empty = executor default. **Docker executor only** - accepted but not enforced on Kubernetes. |
+| `memory_swap` | string | Total memory+swap limit (same format as `memory_limit`); must be set together with `memory_limit` and be `>=` it. **Docker executor only.** |
+| `pids_limit` | int64 | Max PIDs in the container; `0` = unlimited. **Docker executor only.** |
 
 Steps of a job share a per-job volume, so a file written by one step is visible to later steps.
+
+> **Executor parity:** `timeout_seconds`, environment variables (via `metadata`), `cpu_limit` and `memory_limit` are enforced on both the Docker and Kubernetes executors. `network`, `memory_swap` and `pids_limit` are enforced on the Docker executor only; Kubernetes accepts them (for schema parity) but does not apply them, because a pod's containers share one network namespace and Kubernetes has no per-container swap or PID-limit field.
+
+> **CPU unit note:** `cpu_limit` is interpreted as **whole cores** by both executors. (An earlier revision documented millicores; the code has always treated the value as cores.)
 
 > **Priority propagation:** once queued, the numeric priority and its name are attached to the job metadata under the keys `hades.tum.de/priority` and `hades.tum.de/priorityName` (constants `MetadataKeyPriority` / `MetadataKeyPriorityName` in `shared/prio.go`). The operator surfaces `hades.tum.de/priority` as a Job/Pod label.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -123,9 +123,9 @@ Submitted to `POST /build`. Field semantics come from `shared/payload/payload.go
 Steps of a job share a per-job volume, so a file written by one step is visible to later steps.
 
 > **Executor parity:** `timeout_seconds`, environment variables (via `metadata`), `cpu_limit` and `memory_limit` are enforced on both the Docker and Kubernetes executors. `network`, `memory_swap` and `pids_limit` are enforced on the Docker executor only; Kubernetes accepts them (for schema parity) but does not apply them, because a pod's containers share one network namespace and Kubernetes has no per-container swap or PID-limit field.
-
+>
 > **CPU unit note:** `cpu_limit` is interpreted as **whole cores** by both executors. (An earlier revision documented millicores; the code has always treated the value as cores.)
-
+>
 > **Priority propagation:** once queued, the numeric priority and its name are attached to the job metadata under the keys `hades.tum.de/priority` and `hades.tum.de/priorityName` (constants `MetadataKeyPriority` / `MetadataKeyPriorityName` in `shared/prio.go`). The operator surfaces `hades.tum.de/priority` as a Job/Pod label.
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,9 @@ Every component connects to NATS with the same `ConnectionConfig`.
 
 Plus the [NATS](#nats-connection-all-components) and [global](#global-all-components) variables.
 
-> **Reserved (not yet implemented):** `PROMETHEUS_ADDRESS`, `RETENTION_IN_MIN`, `MAX_RETRIES`, and `TIMEOUT_IN_MIN` appear in `.env.example` and some compose files but are **not read by any component today**. They are placeholders for planned features and currently have no effect.
+> **Reserved (not yet implemented):** `PROMETHEUS_ADDRESS`, `RETENTION_IN_MIN`, `MAX_RETRIES`, and `TIMEOUT_IN_MIN` appear in `.env.example` and some compose files but are **not read by any component today**. They are placeholders for planned features and currently have no effect. (Note: a per-job timeout *is* supported, but it is set on the job payload as `timeout_seconds`, not via this env var - see [API: `Step`/`QueuePayload`](./api.md#queuepayload).)
+
+> **Per-job/per-step resource controls** are set on the job payload, not via environment variables: `timeout_seconds` (job), and per-step `cpu_limit`, `memory_limit`, `network`, `memory_swap`, `pids_limit`. Timeout, CPU, memory and environment variables are enforced on both executors; `network`, `memory_swap` and `pids_limit` are Docker-executor only (Kubernetes has no per-container swap/PID field, and a pod's containers share one network namespace). See [api.md](./api.md#step).
 
 ## HadesScheduler
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ Every component connects to NATS with the same `ConnectionConfig`.
 Plus the [NATS](#nats-connection-all-components) and [global](#global-all-components) variables.
 
 > **Reserved (not yet implemented):** `PROMETHEUS_ADDRESS`, `RETENTION_IN_MIN`, `MAX_RETRIES`, and `TIMEOUT_IN_MIN` appear in `.env.example` and some compose files but are **not read by any component today**. They are placeholders for planned features and currently have no effect. (Note: a per-job timeout *is* supported, but it is set on the job payload as `timeout_seconds`, not via this env var - see [API: `Step`/`QueuePayload`](./api.md#queuepayload).)
-
+>
 > **Per-job/per-step resource controls** are set on the job payload, not via environment variables: `timeout_seconds` (job), and per-step `cpu_limit`, `memory_limit`, `network`, `memory_swap`, `pids_limit`. Timeout, CPU, memory and environment variables are enforced on both executors; `network`, `memory_swap` and `pids_limit` are Docker-executor only (Kubernetes has no per-container swap/PID field, and a pod's containers share one network namespace). See [api.md](./api.md#step).
 
 ## HadesScheduler

--- a/helm/hades/crds/build.hades.tum.de_buildjobs.yaml
+++ b/helm/hades/crds/build.hades.tum.de_buildjobs.yaml
@@ -134,6 +134,13 @@ spec:
                         If not specified, uses the value of memoryLimit.
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    memorySwap:
+                      description: |-
+                        Total memory+swap limit (e.g. "512M", "2G"), matching the Docker semantics where
+                        this is memory + swap combined.
+                        Docker executor only: accepted for schema parity but NOT enforced on Kubernetes,
+                        which has no per-container swap field.
+                      type: string
                     metadata:
                       additionalProperties:
                         type: string
@@ -152,6 +159,19 @@ spec:
                         Should clearly indicate what the step does.
                         Examples: "Clone Repository", "Run Tests", "Build Docker Image"
                       type: string
+                    network:
+                      description: |-
+                        Docker network mode for this step (e.g. "none", "bridge", "host", or a named network).
+                        Docker executor only: accepted for schema parity but NOT enforced on Kubernetes,
+                        where all containers in a pod share a single network namespace.
+                      type: string
+                    pidsLimit:
+                      description: |-
+                        Maximum number of PIDs allowed in this step's container; 0 means unlimited.
+                        Docker executor only: accepted for schema parity but NOT enforced on Kubernetes,
+                        which has no per-container PID-limit field.
+                      format: int64
+                      type: integer
                     script:
                       description: |-
                         Optional bash script to execute inside the container.

--- a/shared/payload/example.json
+++ b/shared/payload/example.json
@@ -2,15 +2,15 @@
     "name": "",
     "metadata": {},
     "timestamp": "2021-01-01T00:00:00.000Z",
-    "priority": 1, // optional, default 3
-    "callback_url": "http://localhost:8082/adapter/logs", // optional; where aggregated logs are forwarded. If omitted, logs are not forwarded.
-    "timeout_seconds": 600, // optional; whole-job timeout, 0 = none
+    "priority": 1,
+    "callback_url": "http://localhost:8082/adapter/logs",
+    "timeout_seconds": 600,
     "steps" : [
         {
-            "id" : 1, // mandatory to declare the order of execution
+            "id" : 1,
             "name" : "Clone",
-            "image" : "git:alpine", // mandatory
-            "script" : "echo hello", // optional
+            "image" : "git:alpine",
+            "script" : "echo hello",
             "metadata" : {
                 "GIT_USERNAME[_*]" : "user",
                 "GIT_PASSWORD[_*]" : "pass",
@@ -25,11 +25,11 @@
             "image" : "java:alpine",
             "script" : "maven run",
             "metadata" : {},
-            "cpu_limit": 2, // optional; whole cores (both executors)
-            "memory_limit": "2G", // optional (both executors)
-            "network": "none", // optional; Docker executor only
-            "memory_swap": "2G", // optional; Docker executor only, >= memory_limit
-            "pids_limit": 512 // optional; Docker executor only
+            "cpu_limit": 2,
+            "memory_limit": "2G",
+            "network": "none",
+            "memory_swap": "2G",
+            "pids_limit": 512
         }
     ]
 }

--- a/shared/payload/example.json
+++ b/shared/payload/example.json
@@ -4,7 +4,8 @@
     "timestamp": "2021-01-01T00:00:00.000Z",
     "priority": 1, // optional, default 3
     "callback_url": "http://localhost:8082/adapter/logs", // optional; where aggregated logs are forwarded. If omitted, logs are not forwarded.
-    "jobs" : [
+    "timeout_seconds": 600, // optional; whole-job timeout, 0 = none
+    "steps" : [
         {
             "id" : 1, // mandatory to declare the order of execution
             "name" : "Clone",
@@ -13,7 +14,7 @@
             "metadata" : {
                 "GIT_USERNAME[_*]" : "user",
                 "GIT_PASSWORD[_*]" : "pass",
-                "GIT_URL_*": "fake.fake", 
+                "GIT_URL_*": "fake.fake",
                 "GIT_BRANCH_*": "main",
                 "GIT_COMMIT_*": "hadfuisahsdfui"
             }
@@ -23,7 +24,12 @@
             "name" : "Execute",
             "image" : "java:alpine",
             "script" : "maven run",
-            "metadata" : {}
+            "metadata" : {},
+            "cpu_limit": 2, // optional; whole cores (both executors)
+            "memory_limit": "2G", // optional (both executors)
+            "network": "none", // optional; Docker executor only
+            "memory_swap": "2G", // optional; Docker executor only, >= memory_limit
+            "pids_limit": 512 // optional; Docker executor only
         }
     ]
 }

--- a/shared/payload/payload.go
+++ b/shared/payload/payload.go
@@ -22,25 +22,29 @@ type RESTPayload struct {
 // QueuePayload represents a job to be processed by the Hades system.
 // It contains all information needed to execute a multi-step job.
 type QueuePayload struct {
-	ID          uuid.UUID         `json:"id"`                                  // Unique job identifier
-	Name        string            `json:"name" binding:"required"`             // Human-readable job name
-	Timestamp   time.Time         `json:"timestamp"`                           // Job creation timestamp
-	Metadata    map[string]string `json:"metadata"`                            // Additional job-level metadata
-	Steps       []Step            `json:"steps"`                               // Ordered list of steps to execute
-	CallbackURL string            `json:"callback_url,omitempty" format:"uri"` // Optional per-job destination for forwarding aggregated logs/results. Must be an absolute http/https URL with a host.
+	ID             uuid.UUID         `json:"id"`                                  // Unique job identifier
+	Name           string            `json:"name" binding:"required"`             // Human-readable job name
+	Timestamp      time.Time         `json:"timestamp"`                           // Job creation timestamp
+	Metadata       map[string]string `json:"metadata"`                            // Additional job-level metadata
+	Steps          []Step            `json:"steps"`                               // Ordered list of steps to execute
+	CallbackURL    string            `json:"callback_url,omitempty" format:"uri"` // Optional per-job destination for forwarding aggregated logs/results. Must be an absolute http/https URL with a host.
+	TimeoutSeconds int64             `json:"timeout_seconds,omitempty"`           // Whole-job timeout in seconds; the job is killed and marked failed once exceeded. 0 = no timeout.
 }
 
 // Step represents a single execution step in a job.
 // Each step runs in its own container with the specified image and resources.
 type Step struct {
-	ID              int               `json:"id"`                // Step execution order (starts at 1)
-	Name            string            `json:"name"`              // Human-readable step name
-	Image           string            `json:"image"`             // Container image to use (e.g., "alpine:latest")
-	Script          string            `json:"script"`            // Shell script to execute in the container
-	ContinueOnError bool              `json:"continue_on_error"` // Whether to continue with the next step if this step fails
-	Metadata        map[string]string `json:"metadata"`          // Step-specific environment variables and metadata
-	CPULimit        uint              `json:"cpu_limit"`         // CPU limit in millicores (e.g., 1000 = 1 CPU core)
-	MemoryLimit     string            `json:"memory_limit"`      // Memory limit (e.g., "512M", "2G")
+	ID              int               `json:"id"`                    // Step execution order (starts at 1)
+	Name            string            `json:"name"`                  // Human-readable step name
+	Image           string            `json:"image"`                 // Container image to use (e.g., "alpine:latest")
+	Script          string            `json:"script"`                // Shell script to execute in the container
+	ContinueOnError bool              `json:"continue_on_error"`     // Whether to continue with the next step if this step fails
+	Metadata        map[string]string `json:"metadata"`              // Step-specific environment variables and metadata
+	CPULimit        uint              `json:"cpu_limit"`             // CPU limit in whole cores (e.g., 1 = 1 CPU core, 2 = 2 cores)
+	MemoryLimit     string            `json:"memory_limit"`          // Memory limit (e.g., "512M", "2G")
+	Network         string            `json:"network,omitempty"`     // Docker network mode: "none", "bridge", "host", "default", or a named network. Empty = executor default. Docker executor only; accepted but not enforced on Kubernetes.
+	MemorySwap      string            `json:"memory_swap,omitempty"` // Total memory+swap limit, same format as memory_limit (e.g., "512M", "2G"); must be >= memory_limit. Docker executor only.
+	PidsLimit       int64             `json:"pids_limit,omitempty"`  // Maximum number of PIDs in the container; 0 = unlimited. Docker executor only.
 }
 
 // IDString returns the step ID as a string.

--- a/shared/payload/payload.go
+++ b/shared/payload/payload.go
@@ -10,6 +10,12 @@ import (
 const (
 	// DefaultPriority is the default priority level for jobs when not specified
 	DefaultPriority = 3
+
+	// MaxTimeoutSeconds bounds TimeoutSeconds so that converting it to a
+	// time.Duration (seconds * time.Second) cannot overflow int64 nanoseconds,
+	// which would otherwise wrap to a negative duration and fire immediately.
+	// math.MaxInt64 / 1e9 ≈ 9.2e9 seconds (~292 years).
+	MaxTimeoutSeconds = int64(9223372036)
 )
 
 // RESTPayload represents the HTTP request payload for creating a new job.
@@ -43,7 +49,7 @@ type Step struct {
 	CPULimit        uint              `json:"cpu_limit"`             // CPU limit in whole cores (e.g., 1 = 1 CPU core, 2 = 2 cores)
 	MemoryLimit     string            `json:"memory_limit"`          // Memory limit (e.g., "512M", "2G")
 	Network         string            `json:"network,omitempty"`     // Docker network mode: "none", "bridge", "host", "default", or a named network. Empty = executor default. Docker executor only; accepted but not enforced on Kubernetes.
-	MemorySwap      string            `json:"memory_swap,omitempty"` // Total memory+swap limit, same format as memory_limit (e.g., "512M", "2G"); must be >= memory_limit. Docker executor only.
+	MemorySwap      string            `json:"memory_swap,omitempty"` // Total memory+swap limit, same format as memory_limit (e.g., "512M", "2G"); requires memory_limit to be set and must be >= memory_limit. Docker executor only.
 	PidsLimit       int64             `json:"pids_limit,omitempty"`  // Maximum number of PIDs in the container; 0 = unlimited. Docker executor only.
 }
 

--- a/shared/payload/payload_test.go
+++ b/shared/payload/payload_test.go
@@ -129,6 +129,9 @@ func TestStep_AllFields(t *testing.T) {
 		Metadata:    metadata,
 		CPULimit:    2000,
 		MemoryLimit: "1G",
+		Network:     "none",
+		MemorySwap:  "2G",
+		PidsLimit:   256,
 	}
 
 	assert.Equal(t, 1, step.ID)
@@ -138,5 +141,55 @@ func TestStep_AllFields(t *testing.T) {
 	assert.Equal(t, metadata, step.Metadata)
 	assert.Equal(t, uint(2000), step.CPULimit)
 	assert.Equal(t, "1G", step.MemoryLimit)
+	assert.Equal(t, "none", step.Network)
+	assert.Equal(t, "2G", step.MemorySwap)
+	assert.Equal(t, int64(256), step.PidsLimit)
 	assert.Equal(t, "1", step.IDString())
+}
+
+// The new limit fields must round-trip through JSON and be omitted when unset so
+// legacy clients and payloads are unaffected.
+func TestStep_LimitFields_RoundTrip(t *testing.T) {
+	t.Run("present when set", func(t *testing.T) {
+		s := Step{ID: 1, Image: "alpine", Network: "none", MemorySwap: "2G", PidsLimit: 128}
+		data, err := json.Marshal(s)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"network":"none"`)
+		assert.Contains(t, string(data), `"memory_swap":"2G"`)
+		assert.Contains(t, string(data), `"pids_limit":128`)
+
+		var back Step
+		require.NoError(t, json.Unmarshal(data, &back))
+		assert.Equal(t, s.Network, back.Network)
+		assert.Equal(t, s.MemorySwap, back.MemorySwap)
+		assert.Equal(t, s.PidsLimit, back.PidsLimit)
+	})
+
+	t.Run("omitted when empty", func(t *testing.T) {
+		data, err := json.Marshal(Step{ID: 1, Image: "alpine"})
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "network")
+		assert.NotContains(t, string(data), "memory_swap")
+		assert.NotContains(t, string(data), "pids_limit")
+	})
+}
+
+// timeout_seconds must round-trip on the job and be omitted when unset.
+func TestQueuePayload_TimeoutSeconds_RoundTrip(t *testing.T) {
+	t.Run("present when set", func(t *testing.T) {
+		p := QueuePayload{Name: "job", TimeoutSeconds: 600}
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"timeout_seconds":600`)
+
+		var back QueuePayload
+		require.NoError(t, json.Unmarshal(data, &back))
+		assert.Equal(t, int64(600), back.TimeoutSeconds)
+	})
+
+	t.Run("omitted when zero", func(t *testing.T) {
+		data, err := json.Marshal(QueuePayload{Name: "job"})
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "timeout_seconds")
+	})
 }

--- a/shared/payload/payload_test.go
+++ b/shared/payload/payload_test.go
@@ -127,7 +127,7 @@ func TestStep_AllFields(t *testing.T) {
 		Image:       "alpine/git:latest",
 		Script:      "git clone $GIT_URL",
 		Metadata:    metadata,
-		CPULimit:    2000,
+		CPULimit:    2,
 		MemoryLimit: "1G",
 		Network:     "none",
 		MemorySwap:  "2G",
@@ -139,7 +139,7 @@ func TestStep_AllFields(t *testing.T) {
 	assert.Equal(t, "alpine/git:latest", step.Image)
 	assert.Equal(t, "git clone $GIT_URL", step.Script)
 	assert.Equal(t, metadata, step.Metadata)
-	assert.Equal(t, uint(2000), step.CPULimit)
+	assert.Equal(t, uint(2), step.CPULimit)
 	assert.Equal(t, "1G", step.MemoryLimit)
 	assert.Equal(t, "none", step.Network)
 	assert.Equal(t, "2G", step.MemorySwap)

--- a/shared/utils/config.go
+++ b/shared/utils/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -73,6 +74,28 @@ func ParseMemoryLimit(limit string) (int64, error) {
 	default:
 		return 0, fmt.Errorf("unsupported memory unit %q: must be G (gigabytes) or M (megabytes)", unit)
 	}
+}
+
+// namedNetworkPattern matches a valid Docker network name: it must start with an
+// alphanumeric character and may contain letters, digits, and the separators
+// "_", ".", "-". This rejects whitespace and control characters.
+var namedNetworkPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
+
+// ValidateNetworkMode checks that network is one of the fixed Docker network
+// modes ("none", "bridge", "host", "default") or a valid named network. An empty
+// string is valid and means "executor default".
+func ValidateNetworkMode(network string) error {
+	if network == "" {
+		return nil
+	}
+	switch network {
+	case "none", "bridge", "host", "default":
+		return nil
+	}
+	if !namedNetworkPattern.MatchString(network) {
+		return fmt.Errorf("invalid network mode: must be none, bridge, host, default, or a valid network name")
+	}
+	return nil
 }
 
 // ValidateCallbackURL checks that raw is a well-formed absolute http or https

--- a/shared/utils/config_test.go
+++ b/shared/utils/config_test.go
@@ -128,3 +128,19 @@ func TestParseMemoryLimit_InvalidInput(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNetworkMode(t *testing.T) {
+	valid := []string{"", "none", "bridge", "host", "default", "my-net", "hades_net.1", "artemis-build-network"}
+	for _, n := range valid {
+		t.Run("valid/"+n, func(t *testing.T) {
+			assert.NoError(t, ValidateNetworkMode(n))
+		})
+	}
+
+	invalid := []string{" ", "no ne", "net work", "-leading", ".dot", "bad/slash", "tab\there"}
+	for _, n := range invalid {
+		t.Run("invalid/"+n, func(t *testing.T) {
+			assert.Error(t, ValidateNetworkMode(n))
+		})
+	}
+}

--- a/website/docs/deployment/kubernetes-github-actions.md
+++ b/website/docs/deployment/kubernetes-github-actions.md
@@ -19,9 +19,13 @@ Both are `workflow_dispatch` only - nothing deploys automatically. They call the
 
 ## How a deploy runs
 
-1. **Checkout** the chart source. Prod checks out the **release tag** (when the version is
-   not `latest`) so the chart templates and CRDs match the released images; test uses the
-   ref the workflow was run from.
+1. **Checkout** the chart source. The chart templates and CRDs come from this ref, so it
+   must match the deployed image - especially for CRDs, which Helm never upgrades (see
+   step 5). Prod checks out the **release tag** (when the version is not `latest`). Test
+   resolves the ref automatically: an explicit `chart-ref` input wins; otherwise a `pr-N`
+   version sources the chart/CRDs from that PR's head (`refs/pull/N/head`); otherwise it
+   uses the ref the workflow was run from. This means deploying a `pr-N` image also
+   deploys that PR's CRDs, even when the run is dispatched from `main`.
 2. **Configure kubeconfig** from the environment's `KUBE_CONFIG` secret.
 3. **Ensure the namespace** exists.
 4. **Create/update the app Secrets** (`hades-auth`, `hades-dashboard`) from the
@@ -45,7 +49,10 @@ the release tag verbatim, with no `v` prefix).
 ## Selecting the version
 
 - **Test**: type any image tag. Handy tags: `latest` (current `main`), `pr-123` (a PR
-  build), or a release tag.
+  build), or a release tag. For a `pr-N` tag the chart and CRDs are taken from that PR's
+  head automatically, so you can dispatch from any branch and still get the PR's CRDs. To
+  source the chart from a specific branch or sha instead, set the optional `chart-ref`
+  input.
 - **Prod**: type `latest` or an existing release tag (for example `1.0.0`). A bogus value
   fails the `validate` job before the cluster is touched. The prod deploy pins the chart
   source automatically - `main` for `latest`, or the release tag otherwise - so the chart

--- a/website/static/openapi/hades-api.json
+++ b/website/static/openapi/hades-api.json
@@ -124,6 +124,10 @@
                         "$ref": "#/definitions/payload.Step"
                     }
                 },
+                "timeout_seconds": {
+                    "description": "Whole-job timeout in seconds; the job is killed and marked failed once exceeded. 0 = no timeout.",
+                    "type": "integer"
+                },
                 "timestamp": {
                     "description": "Job creation timestamp",
                     "type": "string"
@@ -138,7 +142,7 @@
                     "type": "boolean"
                 },
                 "cpu_limit": {
-                    "description": "CPU limit in millicores (e.g., 1000 = 1 CPU core)",
+                    "description": "CPU limit in whole cores (e.g., 1 = 1 CPU core, 2 = 2 cores)",
                     "type": "integer"
                 },
                 "id": {
@@ -153,6 +157,10 @@
                     "description": "Memory limit (e.g., \"512M\", \"2G\")",
                     "type": "string"
                 },
+                "memory_swap": {
+                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); must be \u003e= memory_limit. Docker executor only.",
+                    "type": "string"
+                },
                 "metadata": {
                     "description": "Step-specific environment variables and metadata",
                     "type": "object",
@@ -163,6 +171,14 @@
                 "name": {
                     "description": "Human-readable step name",
                     "type": "string"
+                },
+                "network": {
+                    "description": "Docker network mode: \"none\", \"bridge\", \"host\", \"default\", or a named network. Empty = executor default. Docker executor only; accepted but not enforced on Kubernetes.",
+                    "type": "string"
+                },
+                "pids_limit": {
+                    "description": "Maximum number of PIDs in the container; 0 = unlimited. Docker executor only.",
+                    "type": "integer"
                 },
                 "script": {
                     "description": "Shell script to execute in the container",

--- a/website/static/openapi/hades-api.json
+++ b/website/static/openapi/hades-api.json
@@ -158,7 +158,7 @@
                     "type": "string"
                 },
                 "memory_swap": {
-                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); must be \u003e= memory_limit. Docker executor only.",
+                    "description": "Total memory+swap limit, same format as memory_limit (e.g., \"512M\", \"2G\"); requires memory_limit to be set and must be \u003e= memory_limit. Docker executor only.",
                     "type": "string"
                 },
                 "metadata": {


### PR DESCRIPTION
## ✨ What is the change?

Extends the Hades job payload so clients can configure a **whole-job timeout** and **per-step Docker run limits**, enforced on **both** the Docker and Kubernetes executors.

**Payload** (`shared/payload/payload.go`):
- Job-level `timeout_seconds`.
- Per-step `network`, `memory_swap`, `pids_limit`.
- Env vars (via step `metadata`), `cpu_limit` and `memory_limit` already existed and are reused.

**Executor parity:**

| Setting | Field | Docker | Kubernetes |
| --- | --- | --- | --- |
| Timeout | `timeout_seconds` (job) | context deadline | Job `activeDeadlineSeconds` |
| Env vars | step `metadata` | container env | container env |
| CPU / Memory | `cpu_limit` / `memory_limit` | `NanoCPUs` / `Memory` | container resources |
| Network / Swap / PIDs | `network` / `memory_swap` / `pids_limit` | enforced | accepted, **not enforced** (documented) |

Network/swap/pids are Docker-only: Kubernetes has no per-container swap or PID field, and a pod's containers share one network namespace.

Notable correctness details:
- Docker timeout force-removes the still-running container with a fresh context (a cancelled `ContainerWait` does not stop the container), aborts even `ContinueOnError` steps, and publishes the failure status on a non-cancelled context.
- The operator now finalizes a `DeadlineExceeded` job whose pod was already reaped, instead of requeueing an error forever.
- Validation rejects negative timeout/pids, requires `memory_swap >= memory_limit` (and `memory_limit` set), and validates the network mode.
- `cpu_limit` docs corrected to **whole cores** (both executors always treated it that way).

## 📌 Reason for the change / Link to issue

Artemis uses Hades as an alternative CI system and needs to forward its per-exercise build timeout and Docker run flags. Today Hades silently ignores them. See the issue for details and the Artemis integration (ls1intum/Artemis#13113).

Closes #500

## 🧪 Steps for Testing

1. `go test ./...` across the workspace (incl. `HadesScheduler/HadesOperator`).
2. **Docker** (`HADES_EXECUTOR=docker`): submit the new Bruno request *Create Build Job (Resource Limits)* with a short `timeout_seconds` over a long step, plus `network: "none"`, `memory_swap`, `pids_limit`. Verify the job is reported timed-out/failed, no container is leaked, and `docker inspect` shows the limits.
3. **Kubernetes** (`HADES_EXECUTOR=k8s`): submit a job with `timeout_seconds`; verify the generated Job has `activeDeadlineSeconds` and the BuildJob transitions to `Failed` on deadline; verify cpu/memory/env are set per init-container.
4. Regenerated artifacts (`make -C HadesScheduler/HadesOperator manifests generate`, `make docs-api`, `make docs-site-sync`) produce no drift.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added whole-job timeouts, with exceeded limits marking jobs as failed.
  * Added Docker step controls for network mode, memory swap, and process limits.
  * Exposed timeout and resource settings in job details and Kubernetes configurations.
* **Bug Fixes**
  * Improved cancellation, timeout handling, cleanup, and status reporting.
  * Added validation for timeout, memory-swap, PID-limit, and network settings.
* **Documentation**
  * Updated API references and examples, including CPU limits in whole cores.
  * Clarified which settings are enforced by Docker versus Kubernetes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->