### PR TITLE
Skip metadata keys Kubernetes rejects as env var names

### DIFF
--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -628,11 +629,32 @@ func buildK8sJob(bj *buildv1.BuildJob, jobName string, deleteOnComplete bool, su
 	}
 }
 
+// validEnvName matches the names Kubernetes accepts for a container environment
+// variable: C_IDENTIFIER-ish, per the API server's own validation regex.
+var validEnvName = regexp.MustCompile(`^[-._a-zA-Z][-._a-zA-Z0-9]*$`)
+
 // envFromMeta converts a string map to []corev1.EnvVar for container env injection.
 // Keys are sorted so the generated env order is deterministic.
+//
+// Keys that Kubernetes would reject as environment variable names are skipped.
+// Job metadata is a general-purpose string map and Hades itself puts
+// domain-qualified keys in it - "hades.tum.de/priority" and
+// "hades.tum.de/priorityName" are injected by the NATS consumer for every job.
+// A "/" is legal in a label and legal in a Docker env name, but not in a
+// Kubernetes one, so passing them through made the API server reject the whole
+// Job: every job submitted with a priority failed to run on the Kubernetes
+// executor, while the same job ran fine on the Docker executor.
+//
+// Skipping rather than sanitising is deliberate: rewriting a key would invent
+// an env var the submitter never asked for and could silently collide with a
+// real one. The values are still available where they belong - priority is
+// carried as a Job/Pod label by the scheduler.
 func envFromMeta(m map[string]string) []corev1.EnvVar {
 	keys := make([]string, 0, len(m))
 	for k := range m {
+		if !validEnvName.MatchString(k) {
+			continue
+		}
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_envname_test.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_envname_test.go
@@ -1,0 +1,48 @@
+package controller
+
+import (
+	"testing"
+
+	hades "github.com/hades-scheduler/hades/shared"
+)
+
+// TestEnvFromMetaSkipsInvalidKubernetesNames pins the regression that made the
+// Kubernetes executor unable to run ANY job carrying a priority.
+//
+// The NATS consumer injects hades.tum.de/priority and
+// hades.tum.de/priorityName into every job's metadata. The operator turns
+// metadata into container env vars, and "/" is not legal in a Kubernetes env
+// var name, so the API server rejected the entire Job with
+// "Invalid value: \"hades.tum.de/priority\"". The Docker executor accepted the
+// same job, so this only ever broke one variant.
+func TestEnvFromMetaSkipsInvalidKubernetesNames(t *testing.T) {
+	envs := envFromMeta(map[string]string{
+		"VALID_NAME":                  "keep",
+		"also.valid-name":             "keep",
+		hades.MetadataKeyPriority:     "3",
+		hades.MetadataKeyPriorityName: "high",
+		"has spaces":                  "drop",
+		"1leading_digit":              "drop",
+	})
+
+	got := map[string]string{}
+	for _, e := range envs {
+		got[e.Name] = e.Value
+	}
+
+	for _, name := range []string{"VALID_NAME", "also.valid-name"} {
+		if _, ok := got[name]; !ok {
+			t.Errorf("valid env name %q was dropped", name)
+		}
+	}
+	for _, name := range []string{
+		hades.MetadataKeyPriority,
+		hades.MetadataKeyPriorityName,
+		"has spaces",
+		"1leading_digit",
+	} {
+		if _, ok := got[name]; ok {
+			t.Errorf("invalid env name %q was passed to Kubernetes; the API server rejects the whole Job", name)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The Kubernetes executor cannot run **any** job that carries a priority - which is every job.

`shared/nats/consumer.go` injects `hades.tum.de/priority` and `hades.tum.de/priorityName` into job metadata on every delivery. The operator converts metadata into container env vars. A `/` is legal in a Kubernetes label and accepted by Docker, but is **not** legal in a Kubernetes env var name, so the API server rejects the entire Job:

```
Job.batch "buildjob-<id>" is invalid: spec.template.spec.initContainers[0].env[2].name:
Invalid value: "hades.tum.de/priority": a valid environment variable name must consist
of alphabetic characters, digits, '_', '-', or '.'
```

The reconciler retries forever: the BuildJob exists, no Job is ever created, and the job never reaches a terminal state. The Docker executor accepts the same payload, so this breaks exactly one executor.

## Fix

`envFromMeta` skips keys failing Kubernetes' own validation regex instead of passing them through. Skipping rather than sanitising is deliberate - rewriting a key would invent an env var the submitter never asked for and could collide with a real one. Priority is unaffected where it is actually used: the scheduler already carries it as a Job/Pod label.

## How it was found

Submitting a single three-step job to a real single-node k3s cluster. It survived the unit tests because it only manifests when a real API server validates the generated Job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable injection from metadata by excluding names that Kubernetes does not accept, including keys with slashes, spaces, or leading digits.
  * Valid metadata names continue to be injected consistently and in a predictable order.

* **Tests**
  * Added coverage to verify that valid names are preserved and invalid names are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->