### PR TITLE
gofmt HadesAPI/router.go

### DIFF
--- a/HadesAPI/router.go
+++ b/HadesAPI/router.go
@@ -246,13 +246,13 @@ func addBuildToQueue(c *gin.Context, producer hades.JobPublisher, statusPublishe
 	// Always assign server-side (never conditionally): TraceParent is bound from
 	// the request body, so a client-supplied value must not survive into NATS and
 	// the BuildJob annotation when tracing is disabled and Inject returns nil.
-spanCtx, endSpan := timing.StartSpan(c.Request.Context(), "hades.enqueue")
-if carrier := timing.Inject(spanCtx); carrier != nil {
-	p.QueuePayload.TraceParent = carrier["traceparent"]
-} else {
-	p.QueuePayload.TraceParent = ""
-}
-defer endSpan()
+	spanCtx, endSpan := timing.StartSpan(c.Request.Context(), "hades.enqueue")
+	if carrier := timing.Inject(spanCtx); carrier != nil {
+		p.QueuePayload.TraceParent = carrier["traceparent"]
+	} else {
+		p.QueuePayload.TraceParent = ""
+	}
+	defer endSpan()
 
 	err := producer.EnqueueJobWithPriority(spanCtx, p.QueuePayload, queuePrio)
 	if err != nil {


### PR DESCRIPTION
`main` is currently failing `make lint`, which fails CI on **every open PR** built against it:

```
HadesAPI/router.go:249:1: File is not properly formatted (gofmt)
```

The tracing block added in #495 lost its indentation - seven lines sit at column 0 inside a function body. It compiles, so only the gofmt check catches it, and that check passed on #495 before the merge brought the changes together.

`gofmt -w` only, no behaviour change. `make build` and `make lint` both clean afterwards.

Merging this unblocks #505 and #508, whose lint failures are inherited from main rather than caused by their own diffs.