### PR TITLE
Run Kubernetes steps in /shared, matching the Docker executor

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -150,7 +150,7 @@ jobs:
                     image: "ghcr.io/hades-scheduler/hades/junit-result-parser:latest",
                     metadata: {
                       API_ENDPOINT: $result_endpoint,
-                      INGEST_DIR: "./shared/example",
+                      INGEST_DIR: "./example",
                       HADES_TEST_PATH: "./example",
                       HADES_ASSIGNMENT_PATH: "./example/assignment"
                     }

--- a/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_report.yaml
+++ b/HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_report.yaml
@@ -43,7 +43,7 @@ spec:
       image: "ghcr.io/hades-scheduler/hades/junit-result-parser:latest"
       metadata:
         API_ENDPOINT: "https://ma-yu.aet.cit.tum.de/v1/result"
-        INGEST_DIR: "./shared/example"
+        INGEST_DIR: "./example"
         HADES_ASSIGNMENT_PATH: "./example/assignment"
   timeoutSeconds: 600
   maxRetries: 1

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_build_test.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_build_test.go
@@ -197,3 +197,51 @@ func TestBuildK8sJob_NoTimeoutLeavesDeadlineUnset(t *testing.T) {
 		t.Errorf("ActiveDeadlineSeconds = %v, want nil", *job.Spec.ActiveDeadlineSeconds)
 	}
 }
+
+// Every step container must start in the shared volume, matching the Docker
+// executor (HadesScheduler/docker/step.go sets WorkingDir: "/shared").
+//
+// Without this the container inherits whatever WORKDIR its image declares, and
+// an identical job document resolves relative paths differently depending on
+// which executor runs it. That is how the repository's own benchmark payload
+// came to carry INGEST_DIR="./shared/example": correct here, where alpine's
+// WORKDIR is "/", and silently wrong under Docker, where it resolved to
+// /shared/shared/example and the result parser ingested nothing while still
+// exiting 0.
+//
+// The images are chosen to make the failure visible: an image declaring a
+// non-root WORKDIR would previously start somewhere else entirely.
+func TestBuildK8sJob_StepsRunInSharedVolume(t *testing.T) {
+	bj := &buildv1.BuildJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1"},
+		Spec: buildv1.BuildJobSpec{
+			Name: "job-1",
+			Steps: []buildv1.BuildStep{
+				{ID: 1, Name: "scripted", Image: "alpine", Script: "echo hi"},
+				// No script: runs the image entrypoint, which is exactly the
+				// case the result parser hits.
+				{ID: 2, Name: "entrypoint", Image: "ghcr.io/example/parser"},
+			},
+		},
+	}
+
+	job := buildK8sJob(bj, "job-1", true, false)
+
+	for _, id := range []int{1, 2} {
+		c := initContainer(t, job, fmt.Sprintf(BuildStepPrefix, id))
+		if c.WorkingDir != "/shared" {
+			t.Errorf("step %d WorkingDir = %q, want %q", id, c.WorkingDir, "/shared")
+		}
+		// The working directory is only meaningful if the volume is mounted
+		// there, so pin the pair together.
+		var mounted bool
+		for _, m := range c.VolumeMounts {
+			if m.MountPath == "/shared" {
+				mounted = true
+			}
+		}
+		if !mounted {
+			t.Errorf("step %d has WorkingDir /shared but no volume mounted there", id)
+		}
+	}
+}

--- a/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
+++ b/HadesScheduler/HadesOperator/internal/controller/buildjob_controller.go
@@ -546,8 +546,17 @@ func buildK8sJob(bj *buildv1.BuildJob, jobName string, deleteOnComplete bool, su
 		}
 
 		c := corev1.Container{
-			Name:         fmt.Sprintf(BuildStepPrefix, s.ID),
-			Image:        s.Image,
+			Name:  fmt.Sprintf(BuildStepPrefix, s.ID),
+			Image: s.Image,
+			// Match the Docker executor, which sets the working directory to the
+			// shared volume for every step (HadesScheduler/docker/step.go).
+			// Without this the container starts in whatever WORKDIR its image
+			// declares, so an identical job document resolves relative paths
+			// differently on the two executors: with alpine (WORKDIR /) a step
+			// ran in / here and in /shared under Docker, and with an image
+			// declaring WORKDIR /app it would run in /app. That silently breaks
+			// the promise that the same job runs unmodified on either executor.
+			WorkingDir:   sharedMount.MountPath,
 			Env:          envFromMeta(env),
 			VolumeMounts: []corev1.VolumeMount{sharedMount},
 		}


### PR DESCRIPTION
## ✨ What is the change?

The Kubernetes operator now sets `WorkingDir: /shared` on every step
container, matching what the Docker executor already does. The two payloads in
this repository that were written against the old behaviour are corrected to
match.

## 📌 Reason for the change / Link to issue

The Docker executor sets the working directory to the shared volume for every
step:

```go
// HadesScheduler/docker/step.go
WorkingDir: "/shared", // Set the working directory to the shared volume
```

The operator set none, so a step container started in whatever `WORKDIR` its
image declares. **The same job document resolved relative paths differently
depending on which executor ran it.**

Verified on a running deployment rather than inferred. A one-step `alpine` job:

```
# Docker executor
docker executor cwd: /shared
image default cwd:   /

# Kubernetes, from the rendered pod spec
name=step-1 image=alpine:3.21 workingDir=[]
```

`workingDir=[]` means the container falls back to the image's `WORKDIR`, which
is `/` for alpine. Images that declare something else diverge further —
`ghcr.io/hades-scheduler/git-container` declares `WORKDIR /app`, so a relative
path in that step would have resolved against `/app` on Kubernetes and
`/shared` on Docker.

### This has already caused a silent bug here

`.github/workflows/benchmark.yml` passes `INGEST_DIR: "./shared/example"` to
the JUnit result parser. That is correct on Kubernetes (parser image declares
`WORKDIR /`, so it resolves to `/shared/example`) and wrong on Docker, where it
resolves to `/shared/shared/example`.

The failure is quiet. The parser logs

```
level=error msg="Could not parse JUnit XML files into DTOs- lstat ./shared/example: no such file or directory "
```

then carries on and **exits 0**. So the step passes while ingesting nothing.
The same value appears in
`HadesScheduler/HadesOperator/config/samples/build_v1_buildjob_report.yaml`.

Both are changed to `"./example"`, which is correct once the executors agree.

## 🧪 Steps for Testing

`TestBuildK8sJob_StepsRunInSharedVolume` covers it, and was checked to fail
without the production change:

```
--- FAIL: TestBuildK8sJob_StepsRunInSharedVolume (0.00s)
    buildjob_build_test.go:233: step 1 WorkingDir = "", want "/shared"
    buildjob_build_test.go:233: step 2 WorkingDir = "", want "/shared"
```

```bash
go test ./HadesScheduler/HadesOperator/internal/controller/ -run TestBuildK8sJob
```

End to end, submit the same one-step job to both executors and compare:

```json
{"name":"cwd","priority":3,"steps":[
  {"id":1,"name":"pwd","image":"alpine:3.21","script":"pwd"}]}
```

Both should now report `/shared`. Before this change, Docker reported `/shared`
and Kubernetes reported `/`.

## Notes for review

**This is a behavioural change for Kubernetes, not only a fix.** A job that ran
only under the Kubernetes executor and relied on its image's `WORKDIR` will now
start in `/shared` instead.

The argument for changing Kubernetes rather than Docker: any job that has ever
run under the Docker executor already assumes `/shared`, the shared volume is
mounted there on both paths, and `/shared` is the documented place for step I/O.
Aligning Kubernetes to Docker makes the two agree; changing Docker instead would
break every existing job and invent a third behaviour.

The test also pins `WorkingDir` and the volume mount together, since a working
directory is only meaningful if the volume is actually mounted there.

Found while running the Artemis grading payload through both executors for a
benchmark: it succeeded on Kubernetes and failed on Docker, and the working
directory was why.

## ✅ PR Checklist

- [x] I have tested these changes locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Documentation updated (if relevant)
